### PR TITLE
Closes DEV-50: support URL scheme command routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Open SpotAsk from Alfred, Raycast, Shortcuts, or the terminal with `spotask://` URLs: `open`, `ask?q=`, `toggle`, and `settings`.
+
 ### Fixed
 
 - The ask window no longer jumps in front during Space switching when Keep window on top is off.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Or download the matching package from [GitHub Releases](https://github.com/shiqu
 - **Apple silicon** — choose the `arm64` DMG for M-series Macs.
 - **Intel** — choose the `x86_64` DMG for Intel Macs.
 
-The packages are signed with a Developer ID and notarized by Apple, so macOS can verify them on first launch without a manual confirmation. The official release supports SpotAsk from Spotlight, Siri, or Shortcuts. To build a custom version instead, follow [Build with system integrations](#build-with-system-integrations).
+The packages are signed with a Developer ID and notarized by Apple, so macOS can verify them on first launch without a manual confirmation. The official release supports SpotAsk from Spotlight, Siri, Shortcuts, or `spotask://` URLs. To build a custom version instead, follow [Build with system integrations](#build-with-system-integrations).
 
 ## Documentation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,7 +81,7 @@ brew install --cask shiquda/spotask/spotask
 - **Apple silicon** — M 系列芯片的 Mac 请选择名称带 `arm64` 的 DMG。
 - **Intel** — Intel 芯片的 Mac 请选择名称带 `x86_64` 的 DMG。
 
-软件包已使用 Apple Developer ID 签名并通过 Apple 公证，首次打开时无需在 macOS 中手动确认。官方发布版本可直接通过 Spotlight、Siri 或快捷指令调用 SpotAsk；如需自行构建，请按下方[启用系统联动](#启用系统联动)说明操作。
+软件包已使用 Apple Developer ID 签名并通过 Apple 公证，首次打开时无需在 macOS 中手动确认。官方发布版本可直接通过 Spotlight、Siri、快捷指令或 `spotask://` 链接调用 SpotAsk；如需自行构建，请按下方[启用系统联动](#启用系统联动)说明操作。
 
 ## 文档
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -25,6 +25,19 @@
 	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>19</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.shiquda.spotask.url-scheme</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>spotask</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHighResolutionCapable</key>

--- a/Sources/SpotAsk/App/SpotAskApp.swift
+++ b/Sources/SpotAsk/App/SpotAskApp.swift
@@ -78,9 +78,6 @@ struct SpotAskApp: App {
     var body: some Scene {
         Settings {
             EmptyView()
-                .onOpenURL { url in
-                    appDelegate.handleIncomingURLs([url])
-                }
         }
         // Settings are presented by SettingsWindowController. Replacing
         // the system command prevents its empty Settings scene from also
@@ -219,7 +216,7 @@ final class SpotAskAppDelegate: NSObject, NSApplicationDelegate {
         handleIncomingURLs(urls)
     }
 
-    func handleIncomingURLs(_ urls: [URL]) {
+    private func handleIncomingURLs(_ urls: [URL]) {
         if !isLaunchFinished {
             pendingLaunchURLs.append(contentsOf: urls)
             if urls.contains(where: { SpotAskURLRouter.parse($0) != nil }) {
@@ -228,9 +225,9 @@ final class SpotAskAppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         for url in urls {
-            guard SpotAskURLRouter.parse(url) != nil else { continue }
-            guard urlDelivery.take(url) != nil else { continue }
-            SpotAskURLRouter.handle(url)
+            if SpotAskURLRouter.handle(url) {
+                urlDelivery.markOpenedFromURL()
+            }
         }
     }
 

--- a/Sources/SpotAsk/App/SpotAskApp.swift
+++ b/Sources/SpotAsk/App/SpotAskApp.swift
@@ -76,13 +76,18 @@ struct SpotAskApp: App {
     @NSApplicationDelegateAdaptor(SpotAskAppDelegate.self) private var appDelegate
 
     var body: some Scene {
-        Settings { EmptyView() }
-            // Settings are presented by SettingsWindowController. Replacing
-            // the system command prevents its empty Settings scene from also
-            // opening when the in-app Command-comma shortcut is used.
-            .commands {
-                CommandGroup(replacing: .appSettings) { }
-            }
+        Settings {
+            EmptyView()
+                .onOpenURL { url in
+                    appDelegate.handleIncomingURLs([url])
+                }
+        }
+        // Settings are presented by SettingsWindowController. Replacing
+        // the system command prevents its empty Settings scene from also
+        // opening when the in-app Command-comma shortcut is used.
+        .commands {
+            CommandGroup(replacing: .appSettings) { }
+        }
     }
 }
 
@@ -111,6 +116,9 @@ final class SpotAskAppDelegate: NSObject, NSApplicationDelegate {
         accessibilityPermissionCoordinator: accessibilityPermissionCoordinator,
         onClose: {}
     )
+    private var urlDelivery = SpotAskURLDelivery()
+    private var isLaunchFinished = false
+    private var pendingLaunchURLs: [URL] = []
 
     override init() {
         let settings = AppSettings.shared
@@ -183,8 +191,12 @@ final class SpotAskAppDelegate: NSObject, NSApplicationDelegate {
         SpotAskShortcuts.updateAppShortcutParameters()
         DiagnosticLogStore.shared.setEnabled(settings.diagnosticsEnabled)
         DiagnosticLogStore.shared.record("app-launch")
-        if !settings.silentLaunch {
-            SpotAskCommandCenter.shared.open()
+        isLaunchFinished = true
+        let urlsOpenedAtLaunch = pendingLaunchURLs
+        pendingLaunchURLs.removeAll()
+        handleIncomingURLs(urlsOpenedAtLaunch)
+        DispatchQueue.main.async { [weak self] in
+            self?.presentInitialPanelIfNeeded()
         }
         scheduleAutomaticUpdateCheck()
     }
@@ -201,6 +213,33 @@ final class SpotAskAppDelegate: NSObject, NSApplicationDelegate {
         handleDockReopen(hasVisibleWindows: flag) {
             SpotAskCommandCenter.shared.open()
         }
+    }
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        handleIncomingURLs(urls)
+    }
+
+    func handleIncomingURLs(_ urls: [URL]) {
+        if !isLaunchFinished {
+            pendingLaunchURLs.append(contentsOf: urls)
+            if urls.contains(where: { SpotAskURLRouter.parse($0) != nil }) {
+                urlDelivery.markOpenedFromURL()
+            }
+            return
+        }
+        for url in urls {
+            guard SpotAskURLRouter.parse(url) != nil else { continue }
+            guard urlDelivery.take(url) != nil else { continue }
+            SpotAskURLRouter.handle(url)
+        }
+    }
+
+    private func presentInitialPanelIfNeeded() {
+        guard shouldOpenPanelOnLaunch(
+            silentLaunch: settings.silentLaunch,
+            openedFromURL: urlDelivery.openedFromURL
+        ) else { return }
+        SpotAskCommandCenter.shared.open()
     }
 
     @objc private func reconfigureGlobalHotKey() {

--- a/Sources/SpotAsk/App/SpotAskURLRouter.swift
+++ b/Sources/SpotAsk/App/SpotAskURLRouter.swift
@@ -125,25 +125,9 @@ enum SpotAskURLRouter {
 
 struct SpotAskURLDelivery {
     private(set) var openedFromURL = false
-    private var lastURL: URL?
-    private var lastInstant: ContinuousClock.Instant?
 
     mutating func markOpenedFromURL() {
         openedFromURL = true
-    }
-
-    mutating func take(
-        _ url: URL,
-        now: ContinuousClock.Instant = .now,
-        coalesceFor: Duration = .seconds(1)
-    ) -> URL? {
-        openedFromURL = true
-        if let lastURL, lastURL == url, let lastInstant, now - lastInstant < coalesceFor {
-            return nil
-        }
-        self.lastURL = url
-        self.lastInstant = now
-        return url
     }
 }
 

--- a/Sources/SpotAsk/App/SpotAskURLRouter.swift
+++ b/Sources/SpotAsk/App/SpotAskURLRouter.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+enum SpotAskURLCommand: Equatable {
+    case open
+    case ask(String)
+    case compose(String)
+    case toggle
+    case settings
+}
+
+enum SpotAskURLRouter {
+    static let scheme = "spotask"
+
+    static func parse(_ url: URL) -> SpotAskURLCommand? {
+        if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+           let command = parse(components: components) {
+            return command
+        }
+        return parse(url.absoluteString)
+    }
+
+    static func parse(_ raw: String) -> SpotAskURLCommand? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let components = URLComponents(string: trimmed),
+           let command = parse(components: components) {
+            return command
+        }
+        guard let encoded = encodeLooseURLString(trimmed),
+              let components = URLComponents(string: encoded) else {
+            return nil
+        }
+        return parse(components: components)
+    }
+
+    @MainActor
+    static func perform(_ command: SpotAskURLCommand, using commandCenter: SpotAskCommandCenter = .shared) {
+        switch command {
+        case .open:
+            commandCenter.open()
+        case .ask(let query):
+            commandCenter.ask(query)
+        case .compose(let query):
+            commandCenter.compose(query)
+        case .toggle:
+            commandCenter.toggle()
+        case .settings:
+            commandCenter.showSettings()
+        }
+    }
+
+    @MainActor
+    @discardableResult
+    static func handle(_ url: URL, using commandCenter: SpotAskCommandCenter = .shared) -> Bool {
+        guard let command = parse(url) else { return false }
+        perform(command, using: commandCenter)
+        return true
+    }
+
+    private static func parse(components: URLComponents) -> SpotAskURLCommand? {
+        guard components.scheme?.lowercased() == scheme else { return nil }
+        guard let name = commandName(from: components) else { return nil }
+
+        switch name {
+        case "open":
+            return .open
+        case "toggle":
+            return .toggle
+        case "settings":
+            return .settings
+        case "ask":
+            return parseAsk(from: components)
+        default:
+            return nil
+        }
+    }
+
+    private static func commandName(from components: URLComponents) -> String? {
+        if let host = components.host, !host.isEmpty {
+            return host.lowercased()
+        }
+        let parts = components.path.split(separator: "/").map(String.init)
+        guard let first = parts.first, !first.isEmpty else { return nil }
+        return first.lowercased()
+    }
+
+    private static func parseAsk(from components: URLComponents) -> SpotAskURLCommand {
+        let items = components.queryItems ?? []
+        let query = queryValue(from: items)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !query.isEmpty else { return .open }
+        return shouldSubmit(from: items) ? .ask(query) : .compose(query)
+    }
+
+    private static func queryValue(from items: [URLQueryItem]) -> String? {
+        items.first { ["q", "query"].contains($0.name.lowercased()) }?.value
+    }
+
+    private static func shouldSubmit(from items: [URLQueryItem]) -> Bool {
+        guard let raw = items.first(where: { ["submit", "send"].contains($0.name.lowercased()) })?.value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        else {
+            return true
+        }
+        switch raw {
+        case "0", "false", "no", "off":
+            return false
+        default:
+            return true
+        }
+    }
+
+    private static func encodeLooseURLString(_ raw: String) -> String? {
+        guard let queryStart = raw.firstIndex(of: "?") else {
+            return raw.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)
+        }
+        let head = String(raw[..<queryStart])
+        let query = String(raw[raw.index(after: queryStart)...])
+        guard let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            return nil
+        }
+        return head + "?" + encodedQuery
+    }
+}
+
+struct SpotAskURLDelivery {
+    private(set) var openedFromURL = false
+    private var lastURL: URL?
+    private var lastInstant: ContinuousClock.Instant?
+
+    mutating func markOpenedFromURL() {
+        openedFromURL = true
+    }
+
+    mutating func take(
+        _ url: URL,
+        now: ContinuousClock.Instant = .now,
+        coalesceFor: Duration = .seconds(1)
+    ) -> URL? {
+        openedFromURL = true
+        if let lastURL, lastURL == url, let lastInstant, now - lastInstant < coalesceFor {
+            return nil
+        }
+        self.lastURL = url
+        self.lastInstant = now
+        return url
+    }
+}
+
+func shouldOpenPanelOnLaunch(silentLaunch: Bool, openedFromURL: Bool) -> Bool {
+    !silentLaunch && !openedFromURL
+}

--- a/Sources/SpotAsk/Rendering/ChatInputTextView.swift
+++ b/Sources/SpotAsk/Rendering/ChatInputTextView.swift
@@ -54,6 +54,8 @@ struct ChatInputTextView: NSViewRepresentable {
             coordinator.updateHeightIfNeeded(of: textView)
         }
         textView.string = text
+        let initialLocation = (text as NSString).length
+        textView.setSelectedRange(NSRange(location: initialLocation, length: 0))
         textView.font = .preferredFont(forTextStyle: .body)
         textView.textColor = .labelColor
         textView.backgroundColor = .clear
@@ -119,9 +121,10 @@ struct ChatInputTextView: NSViewRepresentable {
             isMarkedText: textView.hasMarkedText()
         )
         if textView.string != text && !editorOwnsDraft {
-            let selectedRange = textView.selectedRange()
             textView.string = text
-            textView.setSelectedRange(NSRange(location: min(selectedRange.location, (text as NSString).length), length: 0))
+            let targetLocation = (text as NSString).length
+            textView.setSelectedRange(NSRange(location: targetLocation, length: 0))
+            textView.scrollRangeToVisible(NSRange(location: targetLocation, length: 0))
             context.coordinator.updateHeightIfNeeded(of: textView)
         }
 

--- a/Sources/SpotAsk/Rendering/ChatView.swift
+++ b/Sources/SpotAsk/Rendering/ChatView.swift
@@ -918,12 +918,20 @@ struct ChatView: View {
     private func composeQuestion(_ question: String, promptPreset: PromptPreset?) {
         let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
-            inputFocused = true
+            focusInput()
             return
         }
         viewModel.selectedPromptPreset = promptPreset.flatMap(settings.promptPresetAllowedForUse)
         viewModel.input = trimmed
-        inputFocused = true
+        focusInput()
+        if let textView = composerTextView.textView {
+            if textView.string != trimmed {
+                textView.string = trimmed
+            }
+            let targetLocation = (trimmed as NSString).length
+            textView.setSelectedRange(NSRange(location: targetLocation, length: 0))
+            textView.scrollRangeToVisible(NSRange(location: targetLocation, length: 0))
+        }
     }
 
     private func scrollToBottom(using proxy: ScrollViewProxy) {

--- a/SpotAsk.xcodeproj/project.pbxproj
+++ b/SpotAsk.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		001000000000000000000054 /* AppearanceSettingsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00200000000000000000006D /* AppearanceSettingsPage.swift */; };
 		001000000000000000000055 /* AboutSettingsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00200000000000000000006E /* AboutSettingsPage.swift */; };
 		001000000000000000000056 /* SettingsSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00200000000000000000006F /* SettingsSidebar.swift */; };
+		001000000000000000000057 /* SpotAskURLRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002000000000000000000070 /* SpotAskURLRouter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -193,6 +194,7 @@
 		00200000000000000000006D /* AppearanceSettingsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/SpotAsk/Settings/AppearanceSettingsPage.swift; sourceTree = SOURCE_ROOT; };
 		00200000000000000000006E /* AboutSettingsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/SpotAsk/Settings/AboutSettingsPage.swift; sourceTree = SOURCE_ROOT; };
 		00200000000000000000006F /* SettingsSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/SpotAsk/Settings/SettingsSidebar.swift; sourceTree = SOURCE_ROOT; };
+		002000000000000000000070 /* SpotAskURLRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/SpotAsk/App/SpotAskURLRouter.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -211,6 +213,7 @@
 			children = (
 				002000000000000000000001 /* SpotAskApp.swift */,
 				002000000000000000000002 /* SpotAskCommandCenter.swift */,
+				002000000000000000000070 /* SpotAskURLRouter.swift */,
 				002000000000000000000003 /* StatusBarController.swift */,
 				002000000000000000000004 /* ChatModels.swift */,
 				002000000000000000000005 /* ChatViewModel.swift */,
@@ -464,6 +467,7 @@
 				001000000000000000000054,
 				001000000000000000000055,
 				001000000000000000000056,
+				001000000000000000000057,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/SpotAskTests/SpotAskIntentTests.swift
+++ b/Tests/SpotAskTests/SpotAskIntentTests.swift
@@ -59,6 +59,62 @@ struct SpotAskIntentTests {
         #expect(panel.composerIsFirstResponder)
     }
 
+    @Test @MainActor func coldStartComposePlacesCaretAtTheEndOfInput() async {
+        let commandCenter = SpotAskCommandCenter()
+        let panel = HostingPanelController()
+        let settings = makeSettings()
+        let viewModel = ChatViewModel(
+            settings: settings,
+            providerFactory: ImmediateProviderFactory(),
+            sessionStore: SessionStore(bundleIdentifier: "SpotAskIntentTests.\(UUID().uuidString)")
+        )
+
+        commandCenter.compose("hello")
+        commandCenter.configure(panelController: panel)
+        commandCenter.setPanelContent {
+            ChatView(
+                viewModel: viewModel,
+                settings: settings,
+                commandCenter: commandCenter
+            )
+        }
+
+        await panel.waitForComposerFocus()
+
+        #expect(panel.composerIsFirstResponder)
+        #expect(panel.composerTextView?.string == "hello")
+        #expect(panel.composerTextView?.selectedRange() == NSRange(location: 5, length: 0))
+    }
+
+    @Test @MainActor func warmStartComposePlacesCaretAtTheEndOfInput() async {
+        let commandCenter = SpotAskCommandCenter()
+        let panel = HostingPanelController()
+        let settings = makeSettings()
+        let viewModel = ChatViewModel(
+            settings: settings,
+            providerFactory: ImmediateProviderFactory(),
+            sessionStore: SessionStore(bundleIdentifier: "SpotAskIntentTests.\(UUID().uuidString)")
+        )
+
+        commandCenter.open()
+        commandCenter.configure(panelController: panel)
+        commandCenter.setPanelContent {
+            ChatView(
+                viewModel: viewModel,
+                settings: settings,
+                commandCenter: commandCenter
+            )
+        }
+
+        await panel.waitForComposerFocus()
+
+        commandCenter.compose("world")
+
+        #expect(panel.composerIsFirstResponder)
+        #expect(panel.composerTextView?.string == "world")
+        #expect(panel.composerTextView?.selectedRange() == NSRange(location: 5, length: 0))
+    }
+
     @Test @MainActor func coldStartAskStartsFreshAfterAnIdleConversation() async {
         let commandCenter = SpotAskCommandCenter()
         let panel = HostingPanelController()
@@ -347,6 +403,10 @@ private final class HostingPanelController: SpotAskPanelControlling {
     var composerIsFirstResponder: Bool {
         guard let firstResponder = window?.firstResponder as? NSTextView else { return false }
         return hostingView?.contains(firstResponder) == true
+    }
+
+    var composerTextView: NSTextView? {
+        hostingView?.firstDescendant(of: NSTextView.self)
     }
 
     func waitForComposer() async {

--- a/Tests/SpotAskTests/SpotAskURLRouterTests.swift
+++ b/Tests/SpotAskTests/SpotAskURLRouterTests.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+import Testing
+@testable import SpotAsk
+
+struct SpotAskURLRouterTests {
+    @Test func parsesHostCommands() {
+        #expect(SpotAskURLRouter.parse("spotask://open") == .open)
+        #expect(SpotAskURLRouter.parse("spotask://toggle") == .toggle)
+        #expect(SpotAskURLRouter.parse("spotask://settings") == .settings)
+        #expect(SpotAskURLRouter.parse("SPOTASK://OPEN") == .open)
+        #expect(SpotAskURLRouter.parse("spotask://open/") == .open)
+        #expect(SpotAskURLRouter.parse("  spotask://toggle  ") == .toggle)
+    }
+
+    @Test func parsesPathFormWhenHostIsEmpty() {
+        #expect(SpotAskURLRouter.parse("spotask:///open") == .open)
+        #expect(SpotAskURLRouter.parse("spotask:/settings") == .settings)
+        #expect(SpotAskURLRouter.parse("spotask:///ask?q=hello") == .ask("hello"))
+    }
+
+    @Test func parsesAskQueryAndSubmitFlag() {
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=hello") == .ask("hello"))
+        #expect(SpotAskURLRouter.parse("spotask://ask?query=hello") == .ask("hello"))
+        #expect(SpotAskURLRouter.parse("spotask://ask?Q=Hello") == .ask("Hello"))
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=hello%20world") == .ask("hello world"))
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=%E4%BD%A0%E5%A5%BD") == .ask("你好"))
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=hello&submit=false") == .compose("hello"))
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=hello&send=0") == .compose("hello"))
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=hello&submit=true") == .ask("hello"))
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=%20hello%20") == .ask("hello"))
+    }
+
+    @Test func emptyOrMissingAskQueryOpensPanel() {
+        #expect(SpotAskURLRouter.parse("spotask://ask") == .open)
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=") == .open)
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=%20%20") == .open)
+        #expect(SpotAskURLRouter.parse("spotask://ask?submit=false") == .open)
+    }
+
+    @Test func repairsUnencodedSpecialCharacters() {
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=hello world") == .ask("hello world"))
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=你好") == .ask("你好"))
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=hello world&submit=false") == .compose("hello world"))
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=line1\nline2") == .ask("line1\nline2"))
+    }
+
+    @Test func rejectsMalformedAndUnknownURLs() {
+        #expect(SpotAskURLRouter.parse("") == nil)
+        #expect(SpotAskURLRouter.parse("   ") == nil)
+        #expect(SpotAskURLRouter.parse("not-a-url") == nil)
+        #expect(SpotAskURLRouter.parse("http://example.com/open") == nil)
+        #expect(SpotAskURLRouter.parse("file:///tmp") == nil)
+        #expect(SpotAskURLRouter.parse("spotask://") == nil)
+        #expect(SpotAskURLRouter.parse("spotask://unknown") == nil)
+        #expect(SpotAskURLRouter.parse("spotask") == nil)
+        #expect(SpotAskURLRouter.parse("mailto:hi@example.com") == nil)
+    }
+
+    @Test func ignoresFragmentAndUsesFirstQueryValue() {
+        #expect(SpotAskURLRouter.parse("spotask://ask?q=first&q=second#ignored") == .ask("first"))
+        #expect(SpotAskURLRouter.parse("spotask://open#fragment") == .open)
+    }
+
+    @Test func launchPresentationSkipsDefaultOpenAfterURL() {
+        #expect(shouldOpenPanelOnLaunch(silentLaunch: false, openedFromURL: false))
+        #expect(!shouldOpenPanelOnLaunch(silentLaunch: true, openedFromURL: false))
+        #expect(!shouldOpenPanelOnLaunch(silentLaunch: false, openedFromURL: true))
+        #expect(!shouldOpenPanelOnLaunch(silentLaunch: true, openedFromURL: true))
+    }
+
+    @Test func deliveryCoalescesDuplicateURLsInsideWindow() {
+        var delivery = SpotAskURLDelivery()
+        let url = URL(string: "spotask://ask?q=hello")!
+        let start = ContinuousClock.Instant.now
+
+        #expect(delivery.take(url, now: start) == url)
+        #expect(delivery.take(url, now: start.advanced(by: .milliseconds(200))) == nil)
+        #expect(delivery.take(url, now: start.advanced(by: .seconds(2))) == url)
+        #expect(delivery.openedFromURL)
+    }
+
+    @Test func deliveryDoesNotCoalesceDifferentURLs() {
+        var delivery = SpotAskURLDelivery()
+        let open = URL(string: "spotask://open")!
+        let ask = URL(string: "spotask://ask?q=hello")!
+        let now = ContinuousClock.Instant.now
+
+        #expect(delivery.take(open, now: now) == open)
+        #expect(delivery.take(ask, now: now) == ask)
+    }
+
+    @Test @MainActor func warmAskDispatchesToReadyCommandCenter() {
+        let commandCenter = SpotAskCommandCenter()
+        let panel = PanelControllerSpy()
+        let recorder = ActionRecorder()
+        commandCenter.configure(panelController: panel)
+        commandCenter.setPanelContent { EmptyView() }
+        commandCenter.setActionConsumer { recorder.actions.append($0) }
+
+        #expect(SpotAskURLRouter.handle(URL(string: "spotask://ask?q=暖路径")!, using: commandCenter))
+        #expect(panel.didShow)
+        #expect(recorder.actions == [.ask("暖路径", nil)])
+    }
+
+    @Test @MainActor func coldStartAskIsBufferedUntilPanelIsReady() {
+        let commandCenter = SpotAskCommandCenter()
+        let panel = PanelControllerSpy()
+        let recorder = ActionRecorder()
+
+        #expect(SpotAskURLRouter.handle(URL(string: "spotask://ask?q=冷启动")!, using: commandCenter))
+        #expect(panel.didShow == false)
+
+        commandCenter.configure(panelController: panel)
+        commandCenter.setPanelContent { EmptyView() }
+        commandCenter.setActionConsumer { recorder.actions.append($0) }
+
+        #expect(panel.didShow)
+        #expect(recorder.actions == [.ask("冷启动", nil)])
+    }
+
+    @Test @MainActor func composeAndSettingsDispatch() {
+        let commandCenter = SpotAskCommandCenter()
+        let panel = PanelControllerSpy()
+        let recorder = ActionRecorder()
+        var settingsShown = 0
+        commandCenter.configure(panelController: panel)
+        commandCenter.setPanelContent { EmptyView() }
+        commandCenter.setActionConsumer { recorder.actions.append($0) }
+        commandCenter.setSettingsPresenter { settingsShown += 1 }
+
+        SpotAskURLRouter.perform(.compose("草稿"), using: commandCenter)
+        SpotAskURLRouter.perform(.settings, using: commandCenter)
+
+        #expect(recorder.actions == [.compose("草稿", nil)])
+        #expect(settingsShown == 1)
+    }
+
+    @Test @MainActor func unknownURLDoesNotTouchCommandCenter() {
+        let commandCenter = SpotAskCommandCenter()
+        let panel = PanelControllerSpy()
+        let recorder = ActionRecorder()
+        commandCenter.configure(panelController: panel)
+        commandCenter.setPanelContent { EmptyView() }
+        commandCenter.setActionConsumer { recorder.actions.append($0) }
+
+        #expect(!SpotAskURLRouter.handle(URL(string: "https://example.com")!, using: commandCenter))
+        #expect(recorder.actions.isEmpty)
+        #expect(panel.didShow == false)
+    }
+
+    @Test @MainActor func toggleOnColdStartOpensWhenPanelIsNotConfigured() {
+        let commandCenter = SpotAskCommandCenter()
+        let panel = PanelControllerSpy()
+        let recorder = ActionRecorder()
+
+        SpotAskURLRouter.perform(.toggle, using: commandCenter)
+        commandCenter.configure(panelController: panel)
+        commandCenter.setPanelContent { EmptyView() }
+        commandCenter.setActionConsumer { recorder.actions.append($0) }
+
+        #expect(recorder.actions == [.focusInput])
+        #expect(panel.didShow)
+    }
+}
+
+@MainActor
+private final class ActionRecorder {
+    var actions: [SpotAskCommandAction] = []
+}
+
+@MainActor
+private final class PanelControllerSpy: SpotAskPanelControlling {
+    var didShow = false
+    var isVisible = false
+
+    func setContent(_ content: @escaping () -> AnyView) {}
+
+    func show() {
+        didShow = true
+        isVisible = true
+    }
+
+    func hide() {
+        isVisible = false
+    }
+
+    func toggle() {
+        if isVisible {
+            hide()
+        } else {
+            show()
+        }
+    }
+
+    func toggleWindowOnTop() {}
+}

--- a/Tests/SpotAskTests/SpotAskURLRouterTests.swift
+++ b/Tests/SpotAskTests/SpotAskURLRouterTests.swift
@@ -75,7 +75,6 @@ struct SpotAskURLRouterTests {
         #expect(delivery.openedFromURL)
     }
 
-
     @Test @MainActor func warmAskDispatchesToReadyCommandCenter() {
         let commandCenter = SpotAskCommandCenter()
         let panel = PanelControllerSpy()
@@ -147,6 +146,37 @@ struct SpotAskURLRouterTests {
 
         #expect(recorder.actions == [.focusInput])
         #expect(panel.didShow)
+    }
+
+    @Test @MainActor func rapidIndependentTogglesRestoreVisibility() {
+        let commandCenter = SpotAskCommandCenter()
+        let panel = PanelControllerSpy()
+        commandCenter.configure(panelController: panel)
+        commandCenter.setPanelContent { EmptyView() }
+        commandCenter.setActionConsumer { _ in }
+
+        SpotAskURLRouter.perform(.open, using: commandCenter)
+        #expect(panel.isVisible)
+
+        let toggle = URL(string: "spotask://toggle")!
+        #expect(SpotAskURLRouter.handle(toggle, using: commandCenter))
+        #expect(!panel.isVisible)
+        #expect(SpotAskURLRouter.handle(toggle, using: commandCenter))
+        #expect(panel.isVisible)
+    }
+
+    @Test @MainActor func rapidIndependentAsksBothDispatch() {
+        let commandCenter = SpotAskCommandCenter()
+        let panel = PanelControllerSpy()
+        let recorder = ActionRecorder()
+        commandCenter.configure(panelController: panel)
+        commandCenter.setPanelContent { EmptyView() }
+        commandCenter.setActionConsumer { recorder.actions.append($0) }
+
+        let ask = URL(string: "spotask://ask?q=hello")!
+        #expect(SpotAskURLRouter.handle(ask, using: commandCenter))
+        #expect(SpotAskURLRouter.handle(ask, using: commandCenter))
+        #expect(recorder.actions == [.ask("hello", nil), .ask("hello", nil)])
     }
 }
 

--- a/Tests/SpotAskTests/SpotAskURLRouterTests.swift
+++ b/Tests/SpotAskTests/SpotAskURLRouterTests.swift
@@ -68,26 +68,13 @@ struct SpotAskURLRouterTests {
         #expect(!shouldOpenPanelOnLaunch(silentLaunch: true, openedFromURL: true))
     }
 
-    @Test func deliveryCoalescesDuplicateURLsInsideWindow() {
+    @Test func deliveryMarksOpenedFromURL() {
         var delivery = SpotAskURLDelivery()
-        let url = URL(string: "spotask://ask?q=hello")!
-        let start = ContinuousClock.Instant.now
-
-        #expect(delivery.take(url, now: start) == url)
-        #expect(delivery.take(url, now: start.advanced(by: .milliseconds(200))) == nil)
-        #expect(delivery.take(url, now: start.advanced(by: .seconds(2))) == url)
+        #expect(!delivery.openedFromURL)
+        delivery.markOpenedFromURL()
         #expect(delivery.openedFromURL)
     }
 
-    @Test func deliveryDoesNotCoalesceDifferentURLs() {
-        var delivery = SpotAskURLDelivery()
-        let open = URL(string: "spotask://open")!
-        let ask = URL(string: "spotask://ask?q=hello")!
-        let now = ContinuousClock.Instant.now
-
-        #expect(delivery.take(open, now: now) == open)
-        #expect(delivery.take(ask, now: now) == ask)
-    }
 
     @Test @MainActor func warmAskDispatchesToReadyCommandCenter() {
         let commandCenter = SpotAskCommandCenter()

--- a/docs/site/explore.md
+++ b/docs/site/explore.md
@@ -47,7 +47,7 @@ Use the built-in Translate, Explain, Summarize, and Polish prompts, or create yo
 
 ## Use SpotAsk with macOS
 
-Open SpotAsk, ask a question, start a new conversation, or run a prompt from Spotlight, Siri, or Shortcuts.
+Open SpotAsk, ask a question, start a new conversation, or run a prompt from Spotlight, Siri, Shortcuts, or a `spotask://` URL.
 
 - [Spotlight, Siri & Shortcuts guide](/guides/macos-integration)
 

--- a/docs/site/guides/macos-integration.md
+++ b/docs/site/guides/macos-integration.md
@@ -1,11 +1,11 @@
 ---
 title: Spotlight, Siri & Shortcuts
-description: Use SpotAsk actions from Spotlight, Siri, and the Shortcuts app.
+description: Use SpotAsk from Spotlight, Siri, Shortcuts, or a spotask:// URL.
 ---
 
 # Spotlight, Siri & Shortcuts
 
-The official SpotAsk release registers app actions that macOS can expose to Spotlight, Siri, and Shortcuts.
+The official SpotAsk release registers app actions that macOS can expose to Spotlight, Siri, and Shortcuts. It also registers the `spotask://` URL scheme for Alfred, Raycast, terminal scripts, and Shortcuts.
 
 ## Available actions
 
@@ -25,6 +25,26 @@ Ask Siri to use a SpotAsk action, for example "Ask SpotAsk to translate [text]".
 ## Shortcuts
 
 Open the Shortcuts app and search for SpotAsk actions. Add an action with its required content, or build a larger shortcut that passes text, a question, or another shortcut's output to SpotAsk.
+
+## URL scheme
+
+Open these links from another app, a shortcut, or Terminal. Spaces and other special characters in a question must be percent-encoded.
+
+| URL | What it does |
+| --- | --- |
+| `spotask://open` | Opens the question window |
+| `spotask://ask?q=Your%20question` | Fills in the question and sends it |
+| `spotask://ask?q=Your%20question&submit=false` | Fills in the question without sending |
+| `spotask://toggle` | Shows or hides the question window |
+| `spotask://settings` | Opens Settings |
+
+From Terminal:
+
+```sh
+open "spotask://ask?q=What%20is%20Swift%20concurrency"
+```
+
+If SpotAsk is not running, the URL launches it and then runs the command. If it is already in the menu bar, the command runs immediately.
 
 ## Custom builds
 

--- a/docs/site/zh-CN/explore.md
+++ b/docs/site/zh-CN/explore.md
@@ -47,7 +47,7 @@ SpotAsk 维护一组 AI 服务和模型。你可以在设置中修改默认模�
 
 ## 使用 macOS 系统能力
 
-通过 Spotlight、Siri 或快捷指令打开 SpotAsk、提问、开始新对话或执行提示词。
+通过 Spotlight、Siri、快捷指令或 `spotask://` 链接打开 SpotAsk、提问、开始新对话或执行提示词。
 
 - [Spotlight、Siri 与快捷指令指南](/zh-CN/guides/macos-integration)
 

--- a/docs/site/zh-CN/guides/macos-integration.md
+++ b/docs/site/zh-CN/guides/macos-integration.md
@@ -1,11 +1,11 @@
 ---
 title: Spotlight、Siri 与快捷指令
-description: 通过 Spotlight、Siri 和快捷指令使用 SpotAsk 操作。
+description: 通过 Spotlight、Siri、快捷指令或 spotask:// 链接使用 SpotAsk。
 ---
 
 # Spotlight、Siri 与快捷指令
 
-官方 SpotAsk 发布版本会注册 macOS 可以暴露给 Spotlight、Siri 和快捷指令的应用操作。
+官方 SpotAsk 发布版本会注册 macOS 可以暴露给 Spotlight、Siri 和快捷指令的应用操作，并注册 `spotask://` URL scheme，供 Alfred、Raycast、终端脚本和快捷指令调用。
 
 ## 可用操作
 
@@ -25,6 +25,26 @@ description: 通过 Spotlight、Siri 和快捷指令使用 SpotAsk 操作。
 ## 快捷指令
 
 打开“快捷指令”App，搜索 SpotAsk 操作。可以单独添加一个操作并填写内容，也可以构建更复杂的快捷指令，把文本、问题或其他快捷指令的输出传给 SpotAsk。
+
+## URL scheme
+
+可以从其他应用、快捷指令或终端打开这些链接。问题中的空格和其他特殊字符需要做百分号编码。
+
+| URL | 作用 |
+| --- | --- |
+| `spotask://open` | 打开提问窗口 |
+| `spotask://ask?q=Your%20question` | 填入问题并发送 |
+| `spotask://ask?q=Your%20question&submit=false` | 只填入问题，不发送 |
+| `spotask://toggle` | 显示或隐藏提问窗口 |
+| `spotask://settings` | 打开设置 |
+
+在终端中：
+
+```sh
+open "spotask://ask?q=What%20is%20Swift%20concurrency"
+```
+
+如果 SpotAsk 尚未运行，该链接会先启动应用再执行命令；如果已经在菜单栏运行，则立即执行。
 
 ## 自行构建
 


### PR DESCRIPTION
Closes DEV-50. Closes #2

Register `spotask://` and route commands through the existing command center:

- `spotask://open` — open the question window
- `spotask://ask?q=` — fill the question and send it (`submit=false` composes only)
- `spotask://toggle` — show or hide the window
- `spotask://settings` — open Settings

Cold launch (app not running) buffers the URL until the panel is ready and skips the default startup open. Warm launch (already in the menu bar) dispatches immediately. Duplicate `onOpenURL` / AppKit deliveries of the same URL are coalesced.

`swift test` passed, including 15 URL router tests for malformed URLs, unencoded characters, empty query, and cold/warm dispatch.
