### PR TITLE
feat(selection): v1.1 action-bar toggles and combined cap of 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The selection action bar can show External Ask targets beside prompt presets. A settings toggle controls this and is on by default.
+- The selection action bar can show External Ask targets beside prompt presets. Separate toggles hide prompts or External Ask (both on by default). Up to six actions share the bar.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The selection action bar can show External Ask targets beside prompt presets. Separate toggles hide prompts or External Ask (both on by default). Up to six actions share the bar.
+- The selection action bar can show External Ask targets beside prompt presets. Separate toggles hide prompts or External Ask (both on by default). Up to eight actions share the bar.
 
 ### Fixed
 
 - The ask window no longer jumps in front during Space switching when Keep window on top is off.
 - Settings switch labels use the available row width instead of the 134pt control column, so longer copy is no longer truncated.
+- The Selection Assistant settings page scrolls when its controls no longer fit the window.
 
 ## [0.2.0] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The selection action bar can show External Ask targets beside prompt presets. A settings toggle controls this and is on by default.
+
 ### Fixed
 
 - The ask window no longer jumps in front during Space switching when Keep window on top is off.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The ask window no longer jumps in front during Space switching when Keep window on top is off.
 - Settings switch labels use the available row width instead of the 134pt control column, so longer copy is no longer truncated.
 - The Selection Assistant settings page scrolls when its controls no longer fit the window.
+- Labeled selection action bar prompts stay inside the 400pt panel: long titles truncate instead of rendering off-canvas. Full names remain on the tooltip.
+- Clearing or failing a selection, or turning the assistant off, dismisses the action bar and drops the captured snapshot.
 
 ## [0.2.0] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The ask window no longer jumps in front during Space switching when Keep window on top is off.
+- Settings switch labels use the available row width instead of the 134pt control column, so longer copy is no longer truncated.
 
 ## [0.2.0] - 2026-08-19
 

--- a/Sources/SpotAsk/App/SpotAskApp.swift
+++ b/Sources/SpotAsk/App/SpotAskApp.swift
@@ -249,6 +249,7 @@ final class SpotAskAppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func reconfigureSelectionHotKey() {
         registerSelectionHotKeyIfNeeded()
+        selectionCoordinator?.handleSettingsChanged()
     }
 
     @objc private func refreshAccessibilityPermission() {

--- a/Sources/SpotAsk/Rendering/QuickActionTrigger.swift
+++ b/Sources/SpotAsk/Rendering/QuickActionTrigger.swift
@@ -7,6 +7,15 @@ import SwiftUI
 enum ResolvedQuickAction: Equatable, Sendable {
     case url(URL)
     case terminalCommand(String)
+
+    static func resolve(_ action: QuickAction, query: String) -> ResolvedQuickAction? {
+        switch action.kind {
+        case let .web(urlTemplate), let .uriScheme(urlTemplate):
+            QuickActionBuilder.makeURL(template: urlTemplate, query: query).map { .url($0) }
+        case let .terminal(commandTemplate):
+            QuickActionBuilder.makeTerminalCommand(template: commandTemplate, query: query).map { .terminalCommand($0) }
+        }
+    }
 }
 
 protocol QuickActionExecuting: Sendable {
@@ -137,25 +146,10 @@ final class QuickActionTrigger {
         let input = currentInput()
 
         // 6. 根据 kind 解析 resolved action (空 query / 无效模板会返回 nil，自然 no-op)
-        let resolved: ResolvedQuickAction?
-        switch action.kind {
-        case let .web(urlTemplate), let .uriScheme(urlTemplate):
-            if let url = QuickActionBuilder.makeURL(template: urlTemplate, query: input) {
-                resolved = .url(url)
-            } else {
-                resolved = nil
-            }
-        case let .terminal(commandTemplate):
-            if let cmd = QuickActionBuilder.makeTerminalCommand(template: commandTemplate, query: input) {
-                resolved = .terminalCommand(cmd)
-            } else {
-                resolved = nil
-            }
-        }
-
-        guard let target = resolved else {
+        guard let target = ResolvedQuickAction.resolve(action, query: input) else {
             return false
         }
+
 
         // 7. 设置 session-scoped isExecutingQuickAction = true
         isExecutingQuickAction = true

--- a/Sources/SpotAsk/Resources/de.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/de.lproj/Localizable.strings
@@ -380,6 +380,7 @@
 "settings.selectionAssistantModeActionBar" = "Schnellaktionen anzeigen";
 "settings.selectionAssistantAutoShow" = "Schnellaktionen nach Textauswahl anzeigen";
 "settings.selectionAssistantActionLabels" = "Beschriftungen neben Symbolen anzeigen";
+"settings.selectionAssistantActionExternalAsk" = "External Ask in der Auswahlleiste anzeigen";
 "settings.selectionAssistantShowsExternalAsk" = "External Ask in der Auswahlleiste anzeigen";
 "settings.selectionAssistantShowsExternalAskDescription" = "Angezeigte Aktionen und Reihenfolge folgen den External-Ask-Einstellungen";
 "selection.actionBar.more" = "Mehr";

--- a/Sources/SpotAsk/Resources/de.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/de.lproj/Localizable.strings
@@ -381,6 +381,8 @@
 "settings.selectionAssistantAutoShow" = "Schnellaktionen nach Textauswahl anzeigen";
 "settings.selectionAssistantActionLabels" = "Beschriftungen neben Symbolen anzeigen";
 "settings.selectionAssistantActionExternalAsk" = "External Ask in der Auswahlleiste anzeigen";
+"settings.selectionAssistantActionPrompts" = "Prompts in der Auswahlleiste anzeigen";
+"settings.selectionAssistantActionBarCrowdingHint" = "Bei vielen Aktionen kann die Leiste zu lang werden. Entfernen Sie selten genutzte Aktionen, oder deaktivieren Sie „Beschriftungen neben Symbolen anzeigen“, um nur Symbole zu zeigen.";
 "settings.selectionAssistantShowsExternalAsk" = "External Ask in der Auswahlleiste anzeigen";
 "settings.selectionAssistantShowsExternalAskDescription" = "Angezeigte Aktionen und Reihenfolge folgen den External-Ask-Einstellungen";
 "selection.actionBar.more" = "Mehr";

--- a/Sources/SpotAsk/Resources/de.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/de.lproj/Localizable.strings
@@ -380,6 +380,14 @@
 "settings.selectionAssistantModeActionBar" = "Schnellaktionen anzeigen";
 "settings.selectionAssistantAutoShow" = "Schnellaktionen nach Textauswahl anzeigen";
 "settings.selectionAssistantActionLabels" = "Beschriftungen neben Symbolen anzeigen";
+"settings.selectionAssistantShowsExternalAsk" = "External Ask in der Auswahlleiste anzeigen";
+"settings.selectionAssistantShowsExternalAskDescription" = "Angezeigte Aktionen und Reihenfolge folgen den External-Ask-Einstellungen";
+"selection.actionBar.more" = "Mehr";
+"selection.actionBar.moreAccessibility" = "Weitere Auswahlaktionen";
+"selection.actionBar.externalAskAccessibility" = "External Ask: %@";
+"selection.actionBar.kind.web" = "Webfrage";
+"selection.actionBar.kind.uriScheme" = "App-Link";
+"selection.actionBar.kind.terminal" = "Terminalbefehl";
 "settings.selectionAssistantAutoShowDelay" = "Warten";
 "settings.selectionAssistantAutoShowDelayUnit" = "s";
 "settings.selectionAssistantDefaultAction" = "Standardaktion";

--- a/Sources/SpotAsk/Resources/en.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/en.lproj/Localizable.strings
@@ -381,6 +381,8 @@
 "settings.selectionAssistantAutoShow" = "Show quick actions after selecting text";
 "settings.selectionAssistantActionLabels" = "Show labels beside icons";
 "settings.selectionAssistantActionExternalAsk" = "Show External Ask in the selection action bar";
+"settings.selectionAssistantActionPrompts" = "Show prompts in the selection action bar";
+"settings.selectionAssistantActionBarCrowdingHint" = "The action bar may get too long when there are many actions. Remove unused ones, or turn off “Show labels beside icons” to show icons only.";
 "settings.selectionAssistantShowsExternalAsk" = "Show External Ask in the selection action bar";
 "settings.selectionAssistantShowsExternalAskDescription" = "Shown actions and order follow the External Ask settings";
 "selection.actionBar.more" = "More";

--- a/Sources/SpotAsk/Resources/en.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/en.lproj/Localizable.strings
@@ -380,6 +380,7 @@
 "settings.selectionAssistantModeActionBar" = "Show quick actions";
 "settings.selectionAssistantAutoShow" = "Show quick actions after selecting text";
 "settings.selectionAssistantActionLabels" = "Show labels beside icons";
+"settings.selectionAssistantActionExternalAsk" = "Show External Ask in the selection action bar";
 "settings.selectionAssistantShowsExternalAsk" = "Show External Ask in the selection action bar";
 "settings.selectionAssistantShowsExternalAskDescription" = "Shown actions and order follow the External Ask settings";
 "selection.actionBar.more" = "More";

--- a/Sources/SpotAsk/Resources/en.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/en.lproj/Localizable.strings
@@ -380,6 +380,14 @@
 "settings.selectionAssistantModeActionBar" = "Show quick actions";
 "settings.selectionAssistantAutoShow" = "Show quick actions after selecting text";
 "settings.selectionAssistantActionLabels" = "Show labels beside icons";
+"settings.selectionAssistantShowsExternalAsk" = "Show External Ask in the selection action bar";
+"settings.selectionAssistantShowsExternalAskDescription" = "Shown actions and order follow the External Ask settings";
+"selection.actionBar.more" = "More";
+"selection.actionBar.moreAccessibility" = "More selection actions";
+"selection.actionBar.externalAskAccessibility" = "External Ask: %@";
+"selection.actionBar.kind.web" = "Web question";
+"selection.actionBar.kind.uriScheme" = "App link";
+"selection.actionBar.kind.terminal" = "Terminal command";
 "settings.selectionAssistantAutoShowDelay" = "Wait";
 "settings.selectionAssistantAutoShowDelayUnit" = "sec";
 "settings.selectionAssistantDefaultAction" = "Default action";

--- a/Sources/SpotAsk/Resources/es.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/es.lproj/Localizable.strings
@@ -380,6 +380,7 @@
 "settings.selectionAssistantModeActionBar" = "Mostrar acciones rápidas";
 "settings.selectionAssistantAutoShow" = "Mostrar acciones rápidas al seleccionar texto";
 "settings.selectionAssistantActionLabels" = "Mostrar etiquetas junto a los iconos";
+"settings.selectionAssistantActionExternalAsk" = "Mostrar External Ask en la barra de selección";
 "settings.selectionAssistantShowsExternalAsk" = "Mostrar External Ask en la barra de selección";
 "settings.selectionAssistantShowsExternalAskDescription" = "Las acciones y el orden siguen los ajustes de External Ask";
 "selection.actionBar.more" = "Más";

--- a/Sources/SpotAsk/Resources/es.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/es.lproj/Localizable.strings
@@ -381,6 +381,8 @@
 "settings.selectionAssistantAutoShow" = "Mostrar acciones rápidas al seleccionar texto";
 "settings.selectionAssistantActionLabels" = "Mostrar etiquetas junto a los iconos";
 "settings.selectionAssistantActionExternalAsk" = "Mostrar External Ask en la barra de selección";
+"settings.selectionAssistantActionPrompts" = "Mostrar prompts en la barra de selección";
+"settings.selectionAssistantActionBarCrowdingHint" = "Con muchas acciones, la barra puede resultar demasiado larga. Quite las que no use, o desactive «Mostrar etiquetas junto a los iconos» para ver solo iconos.";
 "settings.selectionAssistantShowsExternalAsk" = "Mostrar External Ask en la barra de selección";
 "settings.selectionAssistantShowsExternalAskDescription" = "Las acciones y el orden siguen los ajustes de External Ask";
 "selection.actionBar.more" = "Más";

--- a/Sources/SpotAsk/Resources/es.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/es.lproj/Localizable.strings
@@ -380,6 +380,14 @@
 "settings.selectionAssistantModeActionBar" = "Mostrar acciones rápidas";
 "settings.selectionAssistantAutoShow" = "Mostrar acciones rápidas al seleccionar texto";
 "settings.selectionAssistantActionLabels" = "Mostrar etiquetas junto a los iconos";
+"settings.selectionAssistantShowsExternalAsk" = "Mostrar External Ask en la barra de selección";
+"settings.selectionAssistantShowsExternalAskDescription" = "Las acciones y el orden siguen los ajustes de External Ask";
+"selection.actionBar.more" = "Más";
+"selection.actionBar.moreAccessibility" = "Más acciones de selección";
+"selection.actionBar.externalAskAccessibility" = "External Ask: %@";
+"selection.actionBar.kind.web" = "Pregunta web";
+"selection.actionBar.kind.uriScheme" = "Enlace de app";
+"selection.actionBar.kind.terminal" = "Comando de terminal";
 "settings.selectionAssistantAutoShowDelay" = "Esperar";
 "settings.selectionAssistantAutoShowDelayUnit" = "s";
 "settings.selectionAssistantDefaultAction" = "Acción predeterminada";

--- a/Sources/SpotAsk/Resources/fr.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/fr.lproj/Localizable.strings
@@ -381,6 +381,8 @@
 "settings.selectionAssistantAutoShow" = "Afficher les actions rapides après la sélection";
 "settings.selectionAssistantActionLabels" = "Afficher les libellés à côté des icônes";
 "settings.selectionAssistantActionExternalAsk" = "Afficher External Ask dans la barre de sélection";
+"settings.selectionAssistantActionPrompts" = "Afficher les prompts dans la barre de sélection";
+"settings.selectionAssistantActionBarCrowdingHint" = "Avec trop d’actions, la barre peut devenir trop longue. Retirez celles que vous n’utilisez pas, ou désactivez « Afficher les libellés à côté des icônes » pour n’afficher que les icônes.";
 "settings.selectionAssistantShowsExternalAsk" = "Afficher External Ask dans la barre de sélection";
 "settings.selectionAssistantShowsExternalAskDescription" = "Les actions et l’ordre suivent les réglages External Ask";
 "selection.actionBar.more" = "Plus";

--- a/Sources/SpotAsk/Resources/fr.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/fr.lproj/Localizable.strings
@@ -380,6 +380,14 @@
 "settings.selectionAssistantModeActionBar" = "Afficher les actions rapides";
 "settings.selectionAssistantAutoShow" = "Afficher les actions rapides après la sélection";
 "settings.selectionAssistantActionLabels" = "Afficher les libellés à côté des icônes";
+"settings.selectionAssistantShowsExternalAsk" = "Afficher External Ask dans la barre de sélection";
+"settings.selectionAssistantShowsExternalAskDescription" = "Les actions et l’ordre suivent les réglages External Ask";
+"selection.actionBar.more" = "Plus";
+"selection.actionBar.moreAccessibility" = "Autres actions de sélection";
+"selection.actionBar.externalAskAccessibility" = "External Ask : %@";
+"selection.actionBar.kind.web" = "Question web";
+"selection.actionBar.kind.uriScheme" = "Lien d’app";
+"selection.actionBar.kind.terminal" = "Commande Terminal";
 "settings.selectionAssistantAutoShowDelay" = "Attendre";
 "settings.selectionAssistantAutoShowDelayUnit" = "s";
 "settings.selectionAssistantDefaultAction" = "Action par défaut";

--- a/Sources/SpotAsk/Resources/fr.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/fr.lproj/Localizable.strings
@@ -380,6 +380,7 @@
 "settings.selectionAssistantModeActionBar" = "Afficher les actions rapides";
 "settings.selectionAssistantAutoShow" = "Afficher les actions rapides après la sélection";
 "settings.selectionAssistantActionLabels" = "Afficher les libellés à côté des icônes";
+"settings.selectionAssistantActionExternalAsk" = "Afficher External Ask dans la barre de sélection";
 "settings.selectionAssistantShowsExternalAsk" = "Afficher External Ask dans la barre de sélection";
 "settings.selectionAssistantShowsExternalAskDescription" = "Les actions et l’ordre suivent les réglages External Ask";
 "selection.actionBar.more" = "Plus";

--- a/Sources/SpotAsk/Resources/ja.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/ja.lproj/Localizable.strings
@@ -380,6 +380,7 @@
 "settings.selectionAssistantModeActionBar" = "クイックアクションを表示";
 "settings.selectionAssistantAutoShow" = "テキスト選択後にクイックアクションを表示";
 "settings.selectionAssistantActionLabels" = "アイコンの横にラベルを表示";
+"settings.selectionAssistantActionExternalAsk" = "選択アクションバーに External Ask を表示";
 "settings.selectionAssistantShowsExternalAsk" = "選択アクションバーに External Ask を表示";
 "settings.selectionAssistantShowsExternalAskDescription" = "表示する操作と順序は External Ask の設定に従います";
 "selection.actionBar.more" = "その他";

--- a/Sources/SpotAsk/Resources/ja.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/ja.lproj/Localizable.strings
@@ -380,6 +380,14 @@
 "settings.selectionAssistantModeActionBar" = "クイックアクションを表示";
 "settings.selectionAssistantAutoShow" = "テキスト選択後にクイックアクションを表示";
 "settings.selectionAssistantActionLabels" = "アイコンの横にラベルを表示";
+"settings.selectionAssistantShowsExternalAsk" = "選択アクションバーに External Ask を表示";
+"settings.selectionAssistantShowsExternalAskDescription" = "表示する操作と順序は External Ask の設定に従います";
+"selection.actionBar.more" = "その他";
+"selection.actionBar.moreAccessibility" = "その他の選択アクション";
+"selection.actionBar.externalAskAccessibility" = "External Ask：%@";
+"selection.actionBar.kind.web" = "ウェブ質問";
+"selection.actionBar.kind.uriScheme" = "アプリリンク";
+"selection.actionBar.kind.terminal" = "ターミナルコマンド";
 "settings.selectionAssistantAutoShowDelay" = "待機";
 "settings.selectionAssistantAutoShowDelayUnit" = "秒";
 "settings.selectionAssistantDefaultAction" = "既定のアクション";

--- a/Sources/SpotAsk/Resources/ja.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/ja.lproj/Localizable.strings
@@ -381,6 +381,8 @@
 "settings.selectionAssistantAutoShow" = "テキスト選択後にクイックアクションを表示";
 "settings.selectionAssistantActionLabels" = "アイコンの横にラベルを表示";
 "settings.selectionAssistantActionExternalAsk" = "選択アクションバーに External Ask を表示";
+"settings.selectionAssistantActionPrompts" = "選択アクションバーにプロンプトを表示";
+"settings.selectionAssistantActionBarCrowdingHint" = "動作が多いとアクションバーが長くなりすぎることがあります。使わない動作を削除するか、「アイコンの横にラベルを表示」をオフにしてアイコンのみにしてください。";
 "settings.selectionAssistantShowsExternalAsk" = "選択アクションバーに External Ask を表示";
 "settings.selectionAssistantShowsExternalAskDescription" = "表示する操作と順序は External Ask の設定に従います";
 "selection.actionBar.more" = "その他";

--- a/Sources/SpotAsk/Resources/pt.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/pt.lproj/Localizable.strings
@@ -380,6 +380,14 @@
 "settings.selectionAssistantModeActionBar" = "Mostrar ações rápidas";
 "settings.selectionAssistantAutoShow" = "Mostrar ações rápidas após selecionar texto";
 "settings.selectionAssistantActionLabels" = "Mostrar rótulos ao lado dos ícones";
+"settings.selectionAssistantShowsExternalAsk" = "Mostrar External Ask na barra de seleção";
+"settings.selectionAssistantShowsExternalAskDescription" = "As ações e a ordem seguem as definições de External Ask";
+"selection.actionBar.more" = "Mais";
+"selection.actionBar.moreAccessibility" = "Mais ações de seleção";
+"selection.actionBar.externalAskAccessibility" = "External Ask: %@";
+"selection.actionBar.kind.web" = "Pergunta na web";
+"selection.actionBar.kind.uriScheme" = "Ligação de app";
+"selection.actionBar.kind.terminal" = "Comando do Terminal";
 "settings.selectionAssistantAutoShowDelay" = "Aguardar";
 "settings.selectionAssistantAutoShowDelayUnit" = "s";
 "settings.selectionAssistantDefaultAction" = "Ação padrão";

--- a/Sources/SpotAsk/Resources/pt.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/pt.lproj/Localizable.strings
@@ -380,6 +380,7 @@
 "settings.selectionAssistantModeActionBar" = "Mostrar ações rápidas";
 "settings.selectionAssistantAutoShow" = "Mostrar ações rápidas após selecionar texto";
 "settings.selectionAssistantActionLabels" = "Mostrar rótulos ao lado dos ícones";
+"settings.selectionAssistantActionExternalAsk" = "Mostrar External Ask na barra de seleção";
 "settings.selectionAssistantShowsExternalAsk" = "Mostrar External Ask na barra de seleção";
 "settings.selectionAssistantShowsExternalAskDescription" = "As ações e a ordem seguem as definições de External Ask";
 "selection.actionBar.more" = "Mais";

--- a/Sources/SpotAsk/Resources/pt.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/pt.lproj/Localizable.strings
@@ -381,6 +381,8 @@
 "settings.selectionAssistantAutoShow" = "Mostrar ações rápidas após selecionar texto";
 "settings.selectionAssistantActionLabels" = "Mostrar rótulos ao lado dos ícones";
 "settings.selectionAssistantActionExternalAsk" = "Mostrar External Ask na barra de seleção";
+"settings.selectionAssistantActionPrompts" = "Mostrar prompts na barra de seleção";
+"settings.selectionAssistantActionBarCrowdingHint" = "Com muitas ações, a barra pode ficar longa demais. Remova as pouco usadas ou desative «Mostrar rótulos ao lado dos ícones» para ver só os ícones.";
 "settings.selectionAssistantShowsExternalAsk" = "Mostrar External Ask na barra de seleção";
 "settings.selectionAssistantShowsExternalAskDescription" = "As ações e a ordem seguem as definições de External Ask";
 "selection.actionBar.more" = "Mais";

--- a/Sources/SpotAsk/Resources/ru.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/ru.lproj/Localizable.strings
@@ -381,6 +381,8 @@
 "settings.selectionAssistantAutoShow" = "Показывать быстрые действия после выделения";
 "settings.selectionAssistantActionLabels" = "Показывать подписи рядом со значками";
 "settings.selectionAssistantActionExternalAsk" = "Показывать External Ask на панели выделения";
+"settings.selectionAssistantActionPrompts" = "Показывать подсказки на панели выделения";
+"settings.selectionAssistantActionBarCrowdingHint" = "При большом числе действий панель может стать слишком длинной. Уберите редко используемые действия или отключите «Показывать подписи рядом со значками», чтобы оставить только значки.";
 "settings.selectionAssistantShowsExternalAsk" = "Показывать External Ask на панели выделения";
 "settings.selectionAssistantShowsExternalAskDescription" = "Состав и порядок действий берутся из настроек External Ask";
 "selection.actionBar.more" = "Ещё";

--- a/Sources/SpotAsk/Resources/ru.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/ru.lproj/Localizable.strings
@@ -380,6 +380,7 @@
 "settings.selectionAssistantModeActionBar" = "Показать быстрые действия";
 "settings.selectionAssistantAutoShow" = "Показывать быстрые действия после выделения";
 "settings.selectionAssistantActionLabels" = "Показывать подписи рядом со значками";
+"settings.selectionAssistantActionExternalAsk" = "Показывать External Ask на панели выделения";
 "settings.selectionAssistantShowsExternalAsk" = "Показывать External Ask на панели выделения";
 "settings.selectionAssistantShowsExternalAskDescription" = "Состав и порядок действий берутся из настроек External Ask";
 "selection.actionBar.more" = "Ещё";

--- a/Sources/SpotAsk/Resources/ru.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/ru.lproj/Localizable.strings
@@ -380,6 +380,14 @@
 "settings.selectionAssistantModeActionBar" = "Показать быстрые действия";
 "settings.selectionAssistantAutoShow" = "Показывать быстрые действия после выделения";
 "settings.selectionAssistantActionLabels" = "Показывать подписи рядом со значками";
+"settings.selectionAssistantShowsExternalAsk" = "Показывать External Ask на панели выделения";
+"settings.selectionAssistantShowsExternalAskDescription" = "Состав и порядок действий берутся из настроек External Ask";
+"selection.actionBar.more" = "Ещё";
+"selection.actionBar.moreAccessibility" = "Другие действия выделения";
+"selection.actionBar.externalAskAccessibility" = "External Ask: %@";
+"selection.actionBar.kind.web" = "Веб-вопрос";
+"selection.actionBar.kind.uriScheme" = "Ссылка приложения";
+"selection.actionBar.kind.terminal" = "Команда терминала";
 "settings.selectionAssistantAutoShowDelay" = "Подождать";
 "settings.selectionAssistantAutoShowDelayUnit" = "с";
 "settings.selectionAssistantDefaultAction" = "Действие по умолчанию";

--- a/Sources/SpotAsk/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/zh-Hans.lproj/Localizable.strings
@@ -380,6 +380,14 @@
 "settings.selectionAssistantModeActionBar" = "显示快捷操作";
 "settings.selectionAssistantAutoShow" = "选中文字后自动显示快捷操作";
 "settings.selectionAssistantActionLabels" = "在图标旁显示文字";
+"settings.selectionAssistantShowsExternalAsk" = "在划词动作栏中显示外部提问";
+"settings.selectionAssistantShowsExternalAskDescription" = "显示的动作与顺序沿用「外部提问」设置";
+"selection.actionBar.more" = "更多";
+"selection.actionBar.moreAccessibility" = "更多划词动作";
+"selection.actionBar.externalAskAccessibility" = "外部提问：%@";
+"selection.actionBar.kind.web" = "网页提问";
+"selection.actionBar.kind.uriScheme" = "应用跳转";
+"selection.actionBar.kind.terminal" = "终端命令";
 "settings.selectionAssistantAutoShowDelay" = "等待时间";
 "settings.selectionAssistantAutoShowDelayUnit" = "秒";
 "settings.selectionAssistantDefaultAction" = "默认动作";

--- a/Sources/SpotAsk/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/zh-Hans.lproj/Localizable.strings
@@ -380,6 +380,7 @@
 "settings.selectionAssistantModeActionBar" = "显示快捷操作";
 "settings.selectionAssistantAutoShow" = "选中文字后自动显示快捷操作";
 "settings.selectionAssistantActionLabels" = "在图标旁显示文字";
+"settings.selectionAssistantActionExternalAsk" = "在划词动作栏中显示外部提问";
 "settings.selectionAssistantShowsExternalAsk" = "在划词动作栏中显示外部提问";
 "settings.selectionAssistantShowsExternalAskDescription" = "显示的动作与顺序沿用「外部提问」设置";
 "selection.actionBar.more" = "更多";

--- a/Sources/SpotAsk/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/zh-Hans.lproj/Localizable.strings
@@ -381,6 +381,8 @@
 "settings.selectionAssistantAutoShow" = "选中文字后自动显示快捷操作";
 "settings.selectionAssistantActionLabels" = "在图标旁显示文字";
 "settings.selectionAssistantActionExternalAsk" = "在划词动作栏中显示外部提问";
+"settings.selectionAssistantActionPrompts" = "在划词动作栏中显示提示词";
+"settings.selectionAssistantActionBarCrowdingHint" = "动作较多时动作栏可能过长。建议移除不常用的动作，或关闭「显示标签」仅显示图标。";
 "settings.selectionAssistantShowsExternalAsk" = "在划词动作栏中显示外部提问";
 "settings.selectionAssistantShowsExternalAskDescription" = "显示的动作与顺序沿用「外部提问」设置";
 "selection.actionBar.more" = "更多";

--- a/Sources/SpotAsk/Selection/SelectionActionBarView.swift
+++ b/Sources/SpotAsk/Selection/SelectionActionBarView.swift
@@ -2,18 +2,36 @@ import SwiftUI
 
 struct SelectionActionBarView: View {
     let presets: [PromptPreset]
-    let onSelect: (PromptPreset) -> Void
+    let externalAsks: [QuickAction]
+    let onSelectPreset: (PromptPreset) -> Void
+    let onSelectExternalAsk: (QuickAction) -> Void
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: 2) {
             ForEach(presets) { preset in
-                Button { onSelect(preset) } label: {
+                Button { onSelectPreset(preset) } label: {
                     Image(systemName: preset.symbolName)
                         .frame(width: 28, height: 28)
                 }
                 .buttonStyle(.borderless)
                 .help(preset.title)
                 .accessibilityLabel(preset.title)
+            }
+            if !presets.isEmpty && !externalAsks.isEmpty {
+                Divider().frame(height: 18).padding(.horizontal, 4)
+            }
+            ForEach(externalAsks) { action in
+                Button { onSelectExternalAsk(action) } label: {
+                    ProviderBrandIconView(
+                        slug: action.brandIconSlug,
+                        size: 15,
+                        fallbackSymbol: action.symbolName
+                    )
+                    .frame(width: 28, height: 28)
+                }
+                .buttonStyle(.borderless)
+                .help(action.displayName)
+                .accessibilityLabel(action.displayName)
             }
         }
         .padding(5)

--- a/Sources/SpotAsk/Selection/SelectionAssistantCoordinator.swift
+++ b/Sources/SpotAsk/Selection/SelectionAssistantCoordinator.swift
@@ -10,6 +10,7 @@ final class SelectionAssistantCoordinator {
     private let settingsOpener: any AccessibilityPermissionSettingsOpening
     private let commandCenter: SpotAskCommandCenter
     private let overlay: any SelectionOverlayControlling
+    private let executor: any QuickActionExecuting
     private var triggerToken = 0
     private var snapshot: SelectedTextSnapshot?
     private var hasShownPermissionRecovery = false
@@ -22,7 +23,8 @@ final class SelectionAssistantCoordinator {
         permissionCoordinator: AccessibilityPermissionCoordinator,
         settingsOpener: any AccessibilityPermissionSettingsOpening = MacOSAccessibilityPermissionSettingsOpener(),
         commandCenter: SpotAskCommandCenter = .shared,
-        overlay: any SelectionOverlayControlling
+        overlay: any SelectionOverlayControlling,
+        executor: any QuickActionExecuting = DefaultQuickActionExecutor()
     ) {
         self.settings = settings
         self.reader = reader
@@ -31,6 +33,7 @@ final class SelectionAssistantCoordinator {
         self.settingsOpener = settingsOpener
         self.commandCenter = commandCenter
         self.overlay = overlay
+        self.executor = executor
     }
 
     func trigger() {
@@ -88,11 +91,22 @@ final class SelectionAssistantCoordinator {
                 } else {
                     overlay.showActions(
                         snapshot: current,
-                        presets: Array(settings.enabledPromptPresets.prefix(4)),
-                        showsLabels: settings.selectionActionBarShowsLabels
-                    ) { [weak self] preset in
-                        self?.apply(preset: preset)
-                    }
+                        presets: settings.enabledPromptPresets,
+                        quickActions: selectionActionBarQuickActions,
+                        showsLabels: settings.selectionActionBarShowsLabels,
+                        shortcutForPreset: { [settings] preset in
+                            settings.shortcut(for: .promptPreset(preset.id))
+                        },
+                        shortcutForAction: { [settings] action in
+                            settings.shortcut(for: .quickAction(action.id))
+                        },
+                        onSelect: { [weak self] preset in
+                            self?.apply(preset: preset)
+                        },
+                        onSelectQuickAction: { [weak self] action in
+                            self?.apply(quickAction: action)
+                        }
+                    )
                 }
             } catch let error as SelectionReadingError {
                 guard token == triggerToken else { return }
@@ -109,6 +123,26 @@ final class SelectionAssistantCoordinator {
         overlay.hide()
         self.snapshot = nil
         commandCenter.ask(snapshot.text, promptPreset: settings.enabledPromptPreset(id: preset.id), selectionSnapshot: snapshot)
+    }
+
+    private var selectionActionBarQuickActions: [QuickAction] {
+        guard settings.selectionActionBarShowsExternalAsk else { return [] }
+        return settings.enabledQuickActions
+    }
+
+    private func apply(quickAction: QuickAction) {
+        guard let snapshot else { return }
+        overlay.hide()
+        self.snapshot = nil
+        guard settings.externalAskEnabled,
+              settings.selectionActionBarShowsExternalAsk,
+              let action = settings.enabledQuickAction(id: quickAction.id),
+              let resolved = ResolvedQuickAction.resolve(action, query: snapshot.text),
+              executor.perform(resolved)
+        else {
+            overlay.showMessage(.temporaryFailure)
+            return
+        }
     }
 }
 
@@ -133,8 +167,12 @@ protocol SelectionOverlayControlling: AnyObject {
     func showActions(
         snapshot: SelectedTextSnapshot,
         presets: [PromptPreset],
+        quickActions: [QuickAction],
         showsLabels: Bool,
-        onSelect: @escaping (PromptPreset) -> Void
+        shortcutForPreset: @escaping (PromptPreset) -> InAppShortcut?,
+        shortcutForAction: @escaping (QuickAction) -> InAppShortcut?,
+        onSelect: @escaping (PromptPreset) -> Void,
+        onSelectQuickAction: @escaping (QuickAction) -> Void
     )
     func showMessage(_ message: SelectionFeedback)
     func showPermissionDenied(openSettings: @escaping () -> Void)

--- a/Sources/SpotAsk/Selection/SelectionAssistantCoordinator.swift
+++ b/Sources/SpotAsk/Selection/SelectionAssistantCoordinator.swift
@@ -63,8 +63,12 @@ final class SelectionAssistantCoordinator {
     }
 
     private func trigger(showsFeedback: Bool, requiresConfirmedSelection: Bool = false) {
-        guard settings.selectionAssistantEnabled else { return }
+        guard settings.selectionAssistantEnabled else {
+            cancelInFlightAndDiscardPresentedSelection()
+            return
+        }
         guard permissionCoordinator.requestPermissionForSelectionAssistant() == .allowed else {
+            discardPresentedSelection()
             guard showsFeedback, !hasShownPermissionRecovery else { return }
             hasShownPermissionRecovery = true
             overlay.showPermissionDenied { [weak self] in
@@ -81,8 +85,14 @@ final class SelectionAssistantCoordinator {
                 let current = try await reader.readSelection(promptForPermission: false)
                 guard token == triggerToken else { return }
                 // An empty or whitespace-only selection must not wake the assistant.
-                guard !current.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-                guard !requiresConfirmedSelection || current.isConfirmedSelection else { return }
+                guard !current.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    discardPresentedSelection()
+                    return
+                }
+                guard !requiresConfirmedSelection || current.isConfirmedSelection else {
+                    discardPresentedSelection()
+                    return
+                }
                 snapshot = current
                 if settings.selectionAssistantMode == .direct {
                     let preset = settings.selectionPromptPreset()
@@ -91,7 +101,10 @@ final class SelectionAssistantCoordinator {
                 } else {
                     let presets = selectionActionBarPresets
                     let externalAsks = selectionActionBarExternalAsks
-                    guard !presets.isEmpty || !externalAsks.isEmpty else { return }
+                    guard !presets.isEmpty || !externalAsks.isEmpty else {
+                        discardPresentedSelection()
+                        return
+                    }
                     overlay.showActions(
                         snapshot: current,
                         presets: presets,
@@ -113,12 +126,35 @@ final class SelectionAssistantCoordinator {
                 }
             } catch let error as SelectionReadingError {
                 guard token == triggerToken else { return }
+                snapshot = nil
+                overlay.hide()
                 if showsFeedback { overlay.showMessage(error.feedbackMessage) }
             } catch {
                 guard token == triggerToken else { return }
+                snapshot = nil
+                overlay.hide()
                 if showsFeedback { overlay.showMessage(.temporaryFailure) }
             }
         }
+    }
+
+    func handleSettingsChanged() {
+        guard settings.selectionAssistantEnabled else {
+            cancelInFlightAndDiscardPresentedSelection()
+            return
+        }
+    }
+
+    private func cancelInFlightAndDiscardPresentedSelection() {
+        triggerToken += 1
+        automaticTriggerTask?.cancel()
+        automaticTriggerTask = nil
+        discardPresentedSelection()
+    }
+
+    private func discardPresentedSelection() {
+        snapshot = nil
+        overlay.hide()
     }
 
     private func apply(preset: PromptPreset) {

--- a/Sources/SpotAsk/Selection/SelectionAssistantCoordinator.swift
+++ b/Sources/SpotAsk/Selection/SelectionAssistantCoordinator.swift
@@ -91,20 +91,20 @@ final class SelectionAssistantCoordinator {
                 } else {
                     overlay.showActions(
                         snapshot: current,
-                        presets: settings.enabledPromptPresets,
-                        quickActions: selectionActionBarQuickActions,
+                        presets: Array(settings.enabledPromptPresets.prefix(4)),
+                        externalAsks: selectionActionBarExternalAsks,
                         showsLabels: settings.selectionActionBarShowsLabels,
                         shortcutForPreset: { [settings] preset in
                             settings.shortcut(for: .promptPreset(preset.id))
                         },
-                        shortcutForAction: { [settings] action in
+                        shortcutForExternalAsk: { [settings] action in
                             settings.shortcut(for: .quickAction(action.id))
                         },
-                        onSelect: { [weak self] preset in
+                        onSelectPreset: { [weak self] preset in
                             self?.apply(preset: preset)
                         },
-                        onSelectQuickAction: { [weak self] action in
-                            self?.apply(quickAction: action)
+                        onSelectExternalAsk: { [weak self] action in
+                            self?.performExternalAsk(action, snapshot: current)
                         }
                     )
                 }
@@ -125,23 +125,36 @@ final class SelectionAssistantCoordinator {
         commandCenter.ask(snapshot.text, promptPreset: settings.enabledPromptPreset(id: preset.id), selectionSnapshot: snapshot)
     }
 
-    private var selectionActionBarQuickActions: [QuickAction] {
-        guard settings.selectionActionBarShowsExternalAsk else { return [] }
-        return settings.enabledQuickActions
+    private var selectionActionBarExternalAsks: [QuickAction] {
+        guard settings.externalAskEnabled,
+              settings.selectionActionBarShowsExternalAsk
+        else { return [] }
+        return Array(settings.enabledQuickActions.prefix(3))
     }
 
-    private func apply(quickAction: QuickAction) {
-        guard let snapshot else { return }
+    private func performExternalAsk(_ action: QuickAction, snapshot: SelectedTextSnapshot) {
         overlay.hide()
         self.snapshot = nil
         guard settings.externalAskEnabled,
               settings.selectionActionBarShowsExternalAsk,
-              let action = settings.enabledQuickAction(id: quickAction.id),
-              let resolved = ResolvedQuickAction.resolve(action, query: snapshot.text),
-              executor.perform(resolved)
+              let currentAction = settings.enabledQuickAction(id: action.id)
         else {
             overlay.showMessage(.temporaryFailure)
             return
+        }
+        let resolved: ResolvedQuickAction?
+        switch currentAction.kind {
+        case let .web(template), let .uriScheme(template):
+            resolved = QuickActionBuilder.makeURL(template: template, query: snapshot.text).map { .url($0) }
+        case let .terminal(template):
+            resolved = QuickActionBuilder.makeTerminalCommand(template: template, query: snapshot.text).map { .terminalCommand($0) }
+        }
+        guard let resolved else {
+            overlay.showMessage(.temporaryFailure)
+            return
+        }
+        if !executor.perform(resolved) {
+            overlay.showMessage(.temporaryFailure)
         }
     }
 }
@@ -167,14 +180,64 @@ protocol SelectionOverlayControlling: AnyObject {
     func showActions(
         snapshot: SelectedTextSnapshot,
         presets: [PromptPreset],
-        quickActions: [QuickAction],
+        externalAsks: [QuickAction],
         showsLabels: Bool,
-        shortcutForPreset: @escaping (PromptPreset) -> InAppShortcut?,
-        shortcutForAction: @escaping (QuickAction) -> InAppShortcut?,
-        onSelect: @escaping (PromptPreset) -> Void,
-        onSelectQuickAction: @escaping (QuickAction) -> Void
+        onSelectPreset: @escaping (PromptPreset) -> Void,
+        onSelectExternalAsk: @escaping (QuickAction) -> Void
+    )
+    func showActions(
+        snapshot: SelectedTextSnapshot,
+        presets: [PromptPreset],
+        externalAsks: [QuickAction],
+        showsLabels: Bool,
+        shortcutForPreset: ((PromptPreset) -> InAppShortcut?)?,
+        shortcutForExternalAsk: ((QuickAction) -> InAppShortcut?)?,
+        onSelectPreset: @escaping (PromptPreset) -> Void,
+        onSelectExternalAsk: @escaping (QuickAction) -> Void
     )
     func showMessage(_ message: SelectionFeedback)
     func showPermissionDenied(openSettings: @escaping () -> Void)
     func hide()
+}
+
+extension SelectionOverlayControlling {
+    func showActions(
+        snapshot: SelectedTextSnapshot,
+        presets: [PromptPreset],
+        externalAsks: [QuickAction],
+        showsLabels: Bool,
+        onSelectPreset: @escaping (PromptPreset) -> Void,
+        onSelectExternalAsk: @escaping (QuickAction) -> Void
+    ) {
+        showActions(
+            snapshot: snapshot,
+            presets: presets,
+            externalAsks: externalAsks,
+            showsLabels: showsLabels,
+            shortcutForPreset: nil,
+            shortcutForExternalAsk: nil,
+            onSelectPreset: onSelectPreset,
+            onSelectExternalAsk: onSelectExternalAsk
+        )
+    }
+
+    func showActions(
+        snapshot: SelectedTextSnapshot,
+        presets: [PromptPreset],
+        externalAsks: [QuickAction],
+        showsLabels: Bool,
+        shortcutForPreset: ((PromptPreset) -> InAppShortcut?)?,
+        shortcutForExternalAsk: ((QuickAction) -> InAppShortcut?)?,
+        onSelectPreset: @escaping (PromptPreset) -> Void,
+        onSelectExternalAsk: @escaping (QuickAction) -> Void
+    ) {
+        showActions(
+            snapshot: snapshot,
+            presets: presets,
+            externalAsks: externalAsks,
+            showsLabels: showsLabels,
+            onSelectPreset: onSelectPreset,
+            onSelectExternalAsk: onSelectExternalAsk
+        )
+    }
 }

--- a/Sources/SpotAsk/Selection/SelectionAssistantCoordinator.swift
+++ b/Sources/SpotAsk/Selection/SelectionAssistantCoordinator.swift
@@ -89,10 +89,13 @@ final class SelectionAssistantCoordinator {
                     if let preset { commandCenter.ask(current.text, promptPreset: preset, selectionSnapshot: current) }
                     else { commandCenter.compose(current.text) }
                 } else {
+                    let presets = selectionActionBarPresets
+                    let externalAsks = selectionActionBarExternalAsks
+                    guard !presets.isEmpty || !externalAsks.isEmpty else { return }
                     overlay.showActions(
                         snapshot: current,
-                        presets: Array(settings.enabledPromptPresets.prefix(4)),
-                        externalAsks: selectionActionBarExternalAsks,
+                        presets: presets,
+                        externalAsks: externalAsks,
                         showsLabels: settings.selectionActionBarShowsLabels,
                         shortcutForPreset: { [settings] preset in
                             settings.shortcut(for: .promptPreset(preset.id))
@@ -125,11 +128,17 @@ final class SelectionAssistantCoordinator {
         commandCenter.ask(snapshot.text, promptPreset: settings.enabledPromptPreset(id: preset.id), selectionSnapshot: snapshot)
     }
 
+    private var selectionActionBarPresets: [PromptPreset] {
+        guard settings.selectionActionBarShowsPrompts else { return [] }
+        return Array(settings.enabledPromptPresets.prefix(SelectionActionBarLayout.maxTotalActions))
+    }
+
     private var selectionActionBarExternalAsks: [QuickAction] {
         guard settings.externalAskEnabled,
               settings.selectionActionBarShowsExternalAsk
         else { return [] }
-        return Array(settings.enabledQuickActions.prefix(3))
+        let remaining = max(0, SelectionActionBarLayout.maxTotalActions - selectionActionBarPresets.count)
+        return Array(settings.enabledQuickActions.prefix(remaining))
     }
 
     private func performExternalAsk(_ action: QuickAction, snapshot: SelectedTextSnapshot) {

--- a/Sources/SpotAsk/Selection/SelectionOverlayController.swift
+++ b/Sources/SpotAsk/Selection/SelectionOverlayController.swift
@@ -330,7 +330,7 @@ private final class OverlayButtonTarget: NSObject {
 }
 
 struct SelectionActionBarLayout: Equatable {
-    static let maxTotalActions = 6
+    static let maxTotalActions = 8
     static let maxTotalWidth: CGFloat = 400
     static let minExternalAskWidth: CGFloat = 48
     static let controlSize = NSSize(width: 28, height: 28)

--- a/Sources/SpotAsk/Selection/SelectionOverlayController.swift
+++ b/Sources/SpotAsk/Selection/SelectionOverlayController.swift
@@ -7,35 +7,42 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
     private var buttonTargets: [OverlayButtonTarget] = []
     private var globalMouseMonitor: Any?
     private var localMouseMonitor: Any?
-    private var isPresentingMenu = false
-    private var overflowPresets: [PromptPreset] = []
-    private var overflowQuickActions: [QuickAction] = []
-    private var presetShortcut: ((PromptPreset) -> InAppShortcut?)?
-    private var actionShortcut: ((QuickAction) -> InAppShortcut?)?
-    private var selectPreset: ((PromptPreset) -> Void)?
-    private var selectQuickAction: ((QuickAction) -> Void)?
 
     func showActions(
         snapshot: SelectedTextSnapshot,
         presets: [PromptPreset],
-        quickActions: [QuickAction],
+        externalAsks: [QuickAction],
         showsLabels: Bool,
-        shortcutForPreset: @escaping (PromptPreset) -> InAppShortcut?,
-        shortcutForAction: @escaping (QuickAction) -> InAppShortcut?,
-        onSelect: @escaping (PromptPreset) -> Void,
-        onSelectQuickAction: @escaping (QuickAction) -> Void
+        onSelectPreset: @escaping (PromptPreset) -> Void,
+        onSelectExternalAsk: @escaping (QuickAction) -> Void
+    ) {
+        showActions(
+            snapshot: snapshot,
+            presets: presets,
+            externalAsks: externalAsks,
+            showsLabels: showsLabels,
+            shortcutForPreset: nil,
+            shortcutForExternalAsk: nil,
+            onSelectPreset: onSelectPreset,
+            onSelectExternalAsk: onSelectExternalAsk
+        )
+    }
+
+    func showActions(
+        snapshot: SelectedTextSnapshot,
+        presets: [PromptPreset],
+        externalAsks: [QuickAction],
+        showsLabels: Bool,
+        shortcutForPreset: ((PromptPreset) -> InAppShortcut?)?,
+        shortcutForExternalAsk: ((QuickAction) -> InAppShortcut?)?,
+        onSelectPreset: @escaping (PromptPreset) -> Void,
+        onSelectExternalAsk: @escaping (QuickAction) -> Void
     ) {
         let layout = SelectionActionBarLayout.make(
             presets: presets,
-            quickActions: quickActions,
+            externalAsks: externalAsks,
             showsLabels: showsLabels
         )
-        overflowPresets = layout.overflowPresets
-        overflowQuickActions = layout.overflowQuickActions
-        presetShortcut = shortcutForPreset
-        actionShortcut = shortcutForAction
-        selectPreset = onSelect
-        selectQuickAction = onSelectQuickAction
 
         let size = layout.size
         let content = makeContainer(size: size)
@@ -59,8 +66,8 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
 
         for (index, preset) in layout.visiblePresets.enumerated() {
             if index > 0 { placeGroupSpacing() }
-            let width = SelectionActionBarLayout.buttonWidth(for: preset.title, showsLabels: showsLabels)
-            let target = OverlayButtonTarget { onSelect(preset) }
+            let width = layout.visiblePresetWidths[index]
+            let target = OverlayButtonTarget { onSelectPreset(preset) }
             buttonTargets.append(target)
             placeButton(width: width) { frame in
                 makeActionButton(
@@ -71,8 +78,7 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
                     showsLabels: showsLabels,
                     toolTip: SelectionActionBarLayout.tooltip(
                         name: preset.title,
-                        kind: nil,
-                        shortcut: shortcutForPreset(preset)
+                        shortcut: shortcutForPreset?(preset)
                     ),
                     accessibilityLabel: preset.title,
                     target: target
@@ -80,27 +86,25 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
             }
         }
 
-        if layout.showsSeparator {
-            cursorX += SelectionActionBarLayout.separatorMargin
-            let separator = NSView(frame: NSRect(
+        if layout.showsDivider {
+            cursorX += SelectionActionBarLayout.dividerMargin
+            let divider = NSView(frame: NSRect(
                 x: cursorX,
-                y: (size.height - SelectionActionBarLayout.separatorHeight) / 2,
-                width: SelectionActionBarLayout.separatorWidth,
-                height: SelectionActionBarLayout.separatorHeight
+                y: (size.height - SelectionActionBarLayout.dividerHeight) / 2,
+                width: SelectionActionBarLayout.dividerWidth,
+                height: SelectionActionBarLayout.dividerHeight
             ))
-            separator.wantsLayer = true
-            separator.layer?.backgroundColor = NSColor.separatorColor.cgColor
-            separator.setAccessibilityElement(false)
-            content.addSubview(separator)
-            cursorX += SelectionActionBarLayout.separatorWidth + SelectionActionBarLayout.separatorMargin
-        } else if layout.showsMore, !layout.visiblePresets.isEmpty {
-            placeGroupSpacing()
+            divider.wantsLayer = true
+            divider.layer?.backgroundColor = NSColor.separatorColor.cgColor
+            divider.setAccessibilityElement(false)
+            content.addSubview(divider)
+            cursorX += SelectionActionBarLayout.dividerWidth + SelectionActionBarLayout.dividerMargin
         }
 
-        for (index, action) in layout.visibleQuickActions.enumerated() {
+        for (index, action) in layout.visibleExternalAsks.enumerated() {
             if index > 0 { placeGroupSpacing() }
-            let width = SelectionActionBarLayout.buttonWidth(for: action.displayName, showsLabels: showsLabels)
-            let target = OverlayButtonTarget { onSelectQuickAction(action) }
+            let width = layout.visibleExternalAskWidths[index]
+            let target = OverlayButtonTarget { onSelectExternalAsk(action) }
             buttonTargets.append(target)
             placeButton(width: width) { frame in
                 makeActionButton(
@@ -111,38 +115,11 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
                     showsLabels: showsLabels,
                     toolTip: SelectionActionBarLayout.tooltip(
                         name: action.displayName,
-                        kind: SelectionActionBarLayout.kindLabel(for: action.kind),
-                        shortcut: shortcutForAction(action)
+                        shortcut: shortcutForExternalAsk?(action)
                     ),
                     accessibilityLabel: L10n.string("selection.actionBar.externalAskAccessibility", action.displayName),
                     target: target
                 )
-            }
-        }
-
-        if layout.showsMore {
-            if layout.showsSeparator || !layout.visibleQuickActions.isEmpty {
-                if !layout.visibleQuickActions.isEmpty { placeGroupSpacing() }
-            }
-            let moreTitle = L10n.string("selection.actionBar.more")
-            let width = SelectionActionBarLayout.buttonWidth(for: moreTitle, showsLabels: showsLabels)
-            let target = OverlayButtonTarget { [weak self] in
-                self?.presentOverflowMenu()
-            }
-            buttonTargets.append(target)
-            placeButton(width: width) { frame in
-                let button = makeActionButton(
-                    frame: frame,
-                    title: moreTitle,
-                    symbolName: "ellipsis",
-                    brandSlug: nil,
-                    showsLabels: showsLabels,
-                    toolTip: moreTitle,
-                    accessibilityLabel: L10n.string("selection.actionBar.moreAccessibility"),
-                    target: target
-                )
-                button.identifier = NSUserInterfaceItemIdentifier("selection.actionBar.more")
-                return button
             }
         }
 
@@ -188,13 +165,6 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
         dismissWorkItem?.cancel()
         dismissWorkItem = nil
         buttonTargets.removeAll()
-        overflowPresets = []
-        overflowQuickActions = []
-        presetShortcut = nil
-        actionShortcut = nil
-        selectPreset = nil
-        selectQuickAction = nil
-        isPresentingMenu = false
         endOutsideClickMonitoring()
         panel?.orderOut(nil)
         panel = nil
@@ -252,25 +222,30 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
         toolTip: String,
         accessibilityLabel: String,
         target: OverlayButtonTarget
-    ) -> OverlayHoverButton {
+    ) -> NSButton {
+        let button = NSButton(frame: frame)
         let iconPointSize = showsLabels
             ? SelectionActionBarLayout.labeledIconSize
             : SelectionActionBarLayout.compactIconSize
-        let button = OverlayHoverButton(frame: frame)
-        button.iconPointSize = iconPointSize
-        button.symbolName = symbolName
-        button.brandImage = brandImage(for: brandSlug)
-        button.applyRestingIcon()
+
+        if let brandImage = brandImage(for: brandSlug, pointSize: showsLabels ? 13 : SelectionActionBarLayout.compactBrandIconSize) {
+            button.image = brandImage
+        } else if let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityLabel) {
+            button.image = symbol.withSymbolConfiguration(.init(pointSize: iconPointSize, weight: .regular))
+        }
+
         if showsLabels {
             button.title = title
             button.font = .systemFont(ofSize: SelectionActionBarLayout.labelFontSize)
             button.imagePosition = .imageLeading
             button.imageHugsTitle = true
             button.alignment = .left
+            button.lineBreakMode = .byTruncatingTail
         } else {
             button.title = ""
             button.imagePosition = .imageOnly
         }
+
         button.isBordered = false
         button.contentTintColor = .labelColor
         button.toolTip = toolTip
@@ -280,80 +255,14 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
         return button
     }
 
-    private func brandImage(for slug: String?) -> NSImage? {
+    private func brandImage(for slug: String?, pointSize: CGFloat) -> NSImage? {
         guard let slug else { return nil }
-        let dark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        guard let image = ProviderBrandIcon.image(for: slug, dark: dark) else { return nil }
-        image.isTemplate = false
-        return image
-    }
-
-    private func presentOverflowMenu() {
-        guard let moreButton = moreButton() else { return }
-        dismissWorkItem?.cancel()
-        dismissWorkItem = nil
-        isPresentingMenu = true
-
-        let menu = NSMenu()
-        menu.autoenablesItems = false
-        for preset in overflowPresets {
-            menu.addItem(menuItem(
-                title: preset.title,
-                symbolName: preset.symbolName,
-                brandSlug: nil,
-                shortcut: presetShortcut?(preset)
-            ) { [weak self] in
-                self?.selectPreset?(preset)
-            })
-        }
-        for action in overflowQuickActions {
-            menu.addItem(menuItem(
-                title: action.displayName,
-                symbolName: action.symbolName,
-                brandSlug: action.brandIconSlug,
-                shortcut: actionShortcut?(action)
-            ) { [weak self] in
-                self?.selectQuickAction?(action)
-            })
-        }
-
-        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: 0), in: moreButton)
-        isPresentingMenu = false
-        if panel != nil {
-            scheduleDismiss(after: SelectionActionBarLayout.actionBarDismissDelay)
-        }
-    }
-
-    private func menuItem(
-        title: String,
-        symbolName: String,
-        brandSlug: String?,
-        shortcut: InAppShortcut?,
-        handler: @escaping () -> Void
-    ) -> NSMenuItem {
-        let target = OverlayButtonTarget(handler: handler)
-        buttonTargets.append(target)
-        let item = NSMenuItem(title: title, action: #selector(OverlayButtonTarget.invoke), keyEquivalent: "")
-        item.target = target
-        item.isEnabled = true
-        if let brand = brandImage(for: brandSlug) {
-            let icon = brand.copy() as? NSImage ?? brand
-            icon.size = NSSize(width: 16, height: 16)
-            icon.isTemplate = false
-            item.image = icon
-        } else {
-            item.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: title)?
-                .withSymbolConfiguration(.init(pointSize: 13, weight: .regular))
-        }
-        if let shortcut {
-            item.keyEquivalent = shortcut.key == " " ? " " : shortcut.key.lowercased()
-            item.keyEquivalentModifierMask = shortcut.modifierFlags
-        }
-        return item
-    }
-
-    private func moreButton() -> NSView? {
-        panel?.contentView?.subviews.first { $0.identifier?.rawValue == "selection.actionBar.more" }
+        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        guard let image = ProviderBrandIcon.image(for: slug, dark: isDark) else { return nil }
+        let resized = image.copy() as? NSImage ?? image
+        resized.size = NSSize(width: pointSize, height: pointSize)
+        resized.isTemplate = false
+        return resized
     }
 
     private func makePanel(size: NSSize) -> NSPanel {
@@ -392,7 +301,7 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
     }
 
     private func dismissForOutsideClickIfNeeded() {
-        guard !isPresentingMenu, let panel, !panel.frame.contains(NSEvent.mouseLocation) else { return }
+        guard let panel, !panel.frame.contains(NSEvent.mouseLocation) else { return }
         hide()
     }
 
@@ -420,240 +329,155 @@ private final class OverlayButtonTarget: NSObject {
     }
 }
 
-private final class OverlayHoverButton: NSButton {
-    var iconPointSize: CGFloat = SelectionActionBarLayout.compactIconSize
-    var symbolName: String?
-    var brandImage: NSImage?
-    private var hoverTrackingArea: NSTrackingArea?
-    private let hoverFill = CALayer()
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        wantsLayer = true
-        hoverFill.cornerRadius = SelectionActionBarLayout.hoverCornerRadius
-        hoverFill.backgroundColor = NSColor.labelColor.withAlphaComponent(SelectionActionBarLayout.hoverFillOpacity).cgColor
-        hoverFill.opacity = 0
-        layer?.insertSublayer(hoverFill, at: 0)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func layout() {
-        super.layout()
-        hoverFill.frame = bounds
-    }
-
-    override func updateTrackingAreas() {
-        super.updateTrackingAreas()
-        if let hoverTrackingArea {
-            removeTrackingArea(hoverTrackingArea)
-        }
-        let area = NSTrackingArea(
-            rect: bounds,
-            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
-            owner: self,
-            userInfo: nil
-        )
-        addTrackingArea(area)
-        hoverTrackingArea = area
-    }
-
-    override func mouseEntered(with event: NSEvent) {
-        setHovering(true)
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        setHovering(false)
-    }
-
-    func applyRestingIcon() {
-        applyIcon(pointSize: iconPointSize)
-    }
-
-    private func setHovering(_ hovering: Bool) {
-        NSAnimationContext.runAnimationGroup { context in
-            context.duration = SelectionActionBarLayout.hoverDuration
-            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            hoverFill.opacity = hovering ? 1 : 0
-        }
-        applyIcon(pointSize: hovering ? iconPointSize * SelectionActionBarLayout.hoverScale : iconPointSize)
-    }
-
-    private func applyIcon(pointSize: CGFloat) {
-        if let brandImage {
-            let icon = brandImage.copy() as? NSImage ?? brandImage
-            icon.size = NSSize(width: pointSize, height: pointSize)
-            icon.isTemplate = false
-            image = icon
-            return
-        }
-        guard let symbolName,
-              let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: title.isEmpty ? nil : title)
-        else { return }
-        image = symbol.withSymbolConfiguration(.init(pointSize: pointSize, weight: .regular))
-    }
-}
-
 struct SelectionActionBarLayout: Equatable {
-    static let maxVisiblePerGroup = 4
-    static let maxLabeledWidth: CGFloat = 480
+    static let maxPresets = 4
+    static let maxExternalAsks = 3
+    static let maxTotalWidth: CGFloat = 400
+    static let minExternalAskWidth: CGFloat = 48
     static let controlSize = NSSize(width: 28, height: 28)
     static let contentInset: CGFloat = 4
     static let controlSpacing: CGFloat = 2
-    static let separatorWidth: CGFloat = 1
-    static let separatorHeight: CGFloat = 20
-    static let separatorMargin: CGFloat = 6
-    static let separatorOccupiedWidth: CGFloat = separatorWidth + separatorMargin * 2
+    static let dividerWidth: CGFloat = 1
+    static let dividerHeight: CGFloat = 18
+    static let dividerMargin: CGFloat = 4
+    static let dividerOccupiedWidth: CGFloat = dividerWidth + dividerMargin * 2 // 9 pt
     static let labelFontSize: CGFloat = 12
     static let compactIconSize: CGFloat = 15
+    static let compactBrandIconSize: CGFloat = 16
     static let labeledIconSize: CGFloat = 13
-    static let hoverScale: CGFloat = 1.1
-    static let hoverDuration: TimeInterval = 0.12
-    static let hoverCornerRadius: CGFloat = 6
-    static let hoverFillOpacity: CGFloat = 0.08
     static let actionBarDismissDelay: TimeInterval = 8
     static let minimumSize = NSSize(width: 44, height: 36)
 
     var visiblePresets: [PromptPreset]
-    var visibleQuickActions: [QuickAction]
-    var overflowPresets: [PromptPreset]
-    var overflowQuickActions: [QuickAction]
-    var showsSeparator: Bool
-    var showsMore: Bool
+    var visiblePresetWidths: [CGFloat]
+    var visibleExternalAsks: [QuickAction]
+    var visibleExternalAskWidths: [CGFloat]
+    var showsDivider: Bool
     var size: NSSize
 
-    static func make(
-        presets: [PromptPreset],
-        quickActions: [QuickAction],
-        showsLabels: Bool,
-        moreTitle: String = L10n.string("selection.actionBar.more")
-    ) -> SelectionActionBarLayout {
-        var visiblePresets = Array(presets.prefix(maxVisiblePerGroup))
-        var overflowPresets = Array(presets.dropFirst(maxVisiblePerGroup))
-        var visibleQuickActions = Array(quickActions.prefix(maxVisiblePerGroup))
-        var overflowQuickActions = Array(quickActions.dropFirst(maxVisiblePerGroup))
-
-        func current() -> SelectionActionBarLayout {
-            let showsMore = !overflowPresets.isEmpty || !overflowQuickActions.isEmpty
-            let moreOnTrailingGroup = !quickActions.isEmpty
-            let leadingHasContent = !visiblePresets.isEmpty || (showsMore && !moreOnTrailingGroup)
-            let trailingHasContent = !visibleQuickActions.isEmpty || (showsMore && moreOnTrailingGroup)
-            let showsSeparator = leadingHasContent && trailingHasContent
-            let size = barSize(
-                visiblePresets: visiblePresets,
-                visibleQuickActions: visibleQuickActions,
-                showsSeparator: showsSeparator,
-                showsMore: showsMore,
-                moreOnTrailingGroup: moreOnTrailingGroup,
-                showsLabels: showsLabels,
-                moreTitle: moreTitle
-            )
-            return SelectionActionBarLayout(
-                visiblePresets: visiblePresets,
-                visibleQuickActions: visibleQuickActions,
-                overflowPresets: overflowPresets,
-                overflowQuickActions: overflowQuickActions,
-                showsSeparator: showsSeparator,
-                showsMore: showsMore,
-                size: size
-            )
-        }
-
-        var layout = current()
-        if showsLabels {
-            while layout.size.width > maxLabeledWidth {
-                if !visibleQuickActions.isEmpty {
-                    overflowQuickActions.insert(visibleQuickActions.removeLast(), at: 0)
-                } else if !visiblePresets.isEmpty {
-                    overflowPresets.insert(visiblePresets.removeLast(), at: 0)
-                } else {
-                    break
-                }
-                layout = current()
-            }
-        }
-        return layout
-    }
-
-    static func buttonWidth(for title: String, showsLabels: Bool) -> CGFloat {
-        showsLabels ? actionButtonWidth(for: title) : controlSize.width
-    }
-
-    static func actionButtonWidth(for title: String) -> CGFloat {
+    static func buttonWidth(for title: String) -> CGFloat {
         let textWidth = (title as NSString).size(
             withAttributes: [.font: NSFont.systemFont(ofSize: labelFontSize)]
         ).width
-        return ceil(textWidth) + 13 + 4 + 10
+        return ceil(textWidth) + 27
     }
 
-    static func kindLabel(for kind: QuickActionKind) -> String {
-        switch kind {
-        case .web: L10n.string("selection.actionBar.kind.web")
-        case .uriScheme: L10n.string("selection.actionBar.kind.uriScheme")
-        case .terminal: L10n.string("selection.actionBar.kind.terminal")
-        }
+    static func tooltip(name: String, shortcut: InAppShortcut?) -> String {
+        guard let shortcut else { return name }
+        let labels = InAppShortcutDisplay.labels(for: shortcut).joined()
+        return "\(name)\t\(labels)"
     }
 
-    static func tooltip(name: String, kind: String?, shortcut: InAppShortcut?) -> String {
-        var text = name
-        if let kind {
-            text += " — \(kind)"
-        }
-        if let shortcut {
-            text += "（\(InAppShortcutDisplay.labels(for: shortcut).joined())）"
-        }
-        return text
-    }
+    static func make(
+        presets: [PromptPreset],
+        externalAsks: [QuickAction],
+        showsLabels: Bool
+    ) -> SelectionActionBarLayout {
+        let cappedPresets = Array(presets.prefix(maxPresets))
+        let cappedExternalAsks = Array(externalAsks.prefix(maxExternalAsks))
 
-    private static func barSize(
-        visiblePresets: [PromptPreset],
-        visibleQuickActions: [QuickAction],
-        showsSeparator: Bool,
-        showsMore: Bool,
-        moreOnTrailingGroup: Bool,
-        showsLabels: Bool,
-        moreTitle: String
-    ) -> NSSize {
-        let moreWidth = showsMore ? buttonWidth(for: moreTitle, showsLabels: showsLabels) : nil
-        var leading = visiblePresets.map { buttonWidth(for: $0.title, showsLabels: showsLabels) }
-        var trailing = visibleQuickActions.map { buttonWidth(for: $0.displayName, showsLabels: showsLabels) }
-        if let moreWidth {
-            if moreOnTrailingGroup {
-                trailing.append(moreWidth)
-            } else {
-                leading.append(moreWidth)
+        if !showsLabels {
+            var chosenExternalAsks = cappedExternalAsks
+            func compactWidth(pCount: Int, eCount: Int) -> CGFloat {
+                let pWidth = pCount > 0 ? CGFloat(pCount) * controlSize.width + CGFloat(pCount - 1) * controlSpacing : 0
+                let eWidth = eCount > 0 ? CGFloat(eCount) * controlSize.width + CGFloat(eCount - 1) * controlSpacing : 0
+                let div = (pCount > 0 && eCount > 0) ? dividerOccupiedWidth : 0
+                return contentInset * 2 + pWidth + div + eWidth
+            }
+
+            while !chosenExternalAsks.isEmpty && compactWidth(pCount: cappedPresets.count, eCount: chosenExternalAsks.count) > maxTotalWidth {
+                chosenExternalAsks.removeLast()
+            }
+
+            let showsDivider = !cappedPresets.isEmpty && !chosenExternalAsks.isEmpty
+            let totalWidth = compactWidth(pCount: cappedPresets.count, eCount: chosenExternalAsks.count)
+            return SelectionActionBarLayout(
+                visiblePresets: cappedPresets,
+                visiblePresetWidths: Array(repeating: controlSize.width, count: cappedPresets.count),
+                visibleExternalAsks: chosenExternalAsks,
+                visibleExternalAskWidths: Array(repeating: controlSize.width, count: chosenExternalAsks.count),
+                showsDivider: showsDivider,
+                size: NSSize(width: max(minimumSize.width, totalWidth), height: minimumSize.height)
+            )
+        }
+
+        let presetWidths = cappedPresets.map { buttonWidth(for: $0.title) }
+        let pGroupWidth: CGFloat
+        if presetWidths.isEmpty {
+            pGroupWidth = 0
+        } else {
+            pGroupWidth = presetWidths.reduce(0, +) + CGFloat(presetWidths.count - 1) * controlSpacing
+        }
+
+        let hasPresets = !cappedPresets.isEmpty
+        var finalExternalAsks: [QuickAction] = []
+        var finalExternalAskWidths: [CGFloat] = []
+
+        if !cappedExternalAsks.isEmpty {
+            let availableForEA = maxTotalWidth - (contentInset * 2) - pGroupWidth - (hasPresets ? dividerOccupiedWidth : 0)
+            if availableForEA >= minExternalAskWidth {
+                for k in stride(from: cappedExternalAsks.count, through: 1, by: -1) {
+                    let candidates = Array(cappedExternalAsks.prefix(k))
+                    let naturalWidths = candidates.map { buttonWidth(for: $0.displayName) }
+                    let spacingTotal = CGFloat(k - 1) * controlSpacing
+                    let minRequired = CGFloat(k) * minExternalAskWidth + spacingTotal
+
+                    if availableForEA >= minRequired {
+                        let naturalTotal = naturalWidths.reduce(0, +) + spacingTotal
+                        if naturalTotal <= availableForEA {
+                            finalExternalAsks = candidates
+                            finalExternalAskWidths = naturalWidths
+                            break
+                        } else {
+                            let availableForButtons = availableForEA - spacingTotal
+                            var low: CGFloat = minExternalAskWidth
+                            var high: CGFloat = naturalWidths.max() ?? minExternalAskWidth
+                            var bestCap: CGFloat = minExternalAskWidth
+                            for _ in 0..<15 {
+                                let mid = (low + high) / 2
+                                let sum = naturalWidths.map { min($0, mid) }.reduce(0, +)
+                                if sum <= availableForButtons {
+                                    bestCap = mid
+                                    low = mid
+                                } else {
+                                    high = mid
+                                }
+                            }
+                            finalExternalAsks = candidates
+                            finalExternalAskWidths = naturalWidths.map { floor(min($0, bestCap)) }
+                            break
+                        }
+                    }
+                }
             }
         }
 
-        var width = contentInset * 2 + groupWidth(leading)
-        if showsSeparator {
-            width += separatorOccupiedWidth + groupWidth(trailing)
+        let showsDivider = !cappedPresets.isEmpty && !finalExternalAsks.isEmpty
+        let eaGroupWidth: CGFloat
+        if finalExternalAskWidths.isEmpty {
+            eaGroupWidth = 0
         } else {
-            width += groupWidth(trailing)
+            eaGroupWidth = finalExternalAskWidths.reduce(0, +) + CGFloat(finalExternalAskWidths.count - 1) * controlSpacing
         }
-        return NSSize(
-            width: max(minimumSize.width, width),
-            height: max(minimumSize.height, controlSize.height + contentInset * 2)
+
+        var totalWidth = contentInset * 2 + pGroupWidth
+        if showsDivider {
+            totalWidth += dividerOccupiedWidth + eaGroupWidth
+        } else {
+            totalWidth += eaGroupWidth
+        }
+
+        return SelectionActionBarLayout(
+            visiblePresets: cappedPresets,
+            visiblePresetWidths: presetWidths,
+            visibleExternalAsks: finalExternalAsks,
+            visibleExternalAskWidths: finalExternalAskWidths,
+            showsDivider: showsDivider,
+            size: NSSize(
+                width: max(minimumSize.width, min(maxTotalWidth, totalWidth)),
+                height: max(minimumSize.height, controlSize.height + contentInset * 2)
+            )
         )
-    }
-
-    private static func groupWidth(_ widths: [CGFloat]) -> CGFloat {
-        guard !widths.isEmpty else { return 0 }
-        return widths.reduce(0, +) + CGFloat(widths.count - 1) * controlSpacing
-    }
-}
-
-private extension InAppShortcut {
-    var modifierFlags: NSEvent.ModifierFlags {
-        var mask: NSEvent.ModifierFlags = []
-        if modifiers.contains(.command) { mask.insert(.command) }
-        if modifiers.contains(.shift) { mask.insert(.shift) }
-        if modifiers.contains(.option) { mask.insert(.option) }
-        if modifiers.contains(.control) { mask.insert(.control) }
-        return mask
     }
 }
 

--- a/Sources/SpotAsk/Selection/SelectionOverlayController.swift
+++ b/Sources/SpotAsk/Selection/SelectionOverlayController.swift
@@ -46,31 +46,15 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
 
         let size = layout.size
         let content = makeContainer(size: size)
-        var cursorX = SelectionActionBarLayout.contentInset
         buttonTargets = []
 
-        func placeButton(width: CGFloat, configure: (NSRect) -> NSButton) {
-            let frame = NSRect(
-                x: cursorX,
-                y: SelectionActionBarLayout.contentInset,
-                width: width,
-                height: SelectionActionBarLayout.controlSize.height
-            )
-            content.addSubview(configure(frame))
-            cursorX += width
-        }
-
-        func placeGroupSpacing() {
-            cursorX += SelectionActionBarLayout.controlSpacing
-        }
-
-        for (index, preset) in layout.visiblePresets.enumerated() {
-            if index > 0 { placeGroupSpacing() }
-            let width = layout.visiblePresetWidths[index]
-            let target = OverlayButtonTarget { onSelectPreset(preset) }
-            buttonTargets.append(target)
-            placeButton(width: width) { frame in
-                makeActionButton(
+        for item in layout.placedItems {
+            switch item {
+            case let .preset(index, frame):
+                let preset = layout.visiblePresets[index]
+                let target = OverlayButtonTarget { onSelectPreset(preset) }
+                buttonTargets.append(target)
+                content.addSubview(makeActionButton(
                     frame: frame,
                     title: preset.title,
                     symbolName: preset.symbolName,
@@ -82,32 +66,18 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
                     ),
                     accessibilityLabel: preset.title,
                     target: target
-                )
-            }
-        }
-
-        if layout.showsDivider {
-            cursorX += SelectionActionBarLayout.dividerMargin
-            let divider = NSView(frame: NSRect(
-                x: cursorX,
-                y: (size.height - SelectionActionBarLayout.dividerHeight) / 2,
-                width: SelectionActionBarLayout.dividerWidth,
-                height: SelectionActionBarLayout.dividerHeight
-            ))
-            divider.wantsLayer = true
-            divider.layer?.backgroundColor = NSColor.separatorColor.cgColor
-            divider.setAccessibilityElement(false)
-            content.addSubview(divider)
-            cursorX += SelectionActionBarLayout.dividerWidth + SelectionActionBarLayout.dividerMargin
-        }
-
-        for (index, action) in layout.visibleExternalAsks.enumerated() {
-            if index > 0 { placeGroupSpacing() }
-            let width = layout.visibleExternalAskWidths[index]
-            let target = OverlayButtonTarget { onSelectExternalAsk(action) }
-            buttonTargets.append(target)
-            placeButton(width: width) { frame in
-                makeActionButton(
+                ))
+            case let .divider(frame):
+                let divider = NSView(frame: frame)
+                divider.wantsLayer = true
+                divider.layer?.backgroundColor = NSColor.separatorColor.cgColor
+                divider.setAccessibilityElement(false)
+                content.addSubview(divider)
+            case let .externalAsk(index, frame):
+                let action = layout.visibleExternalAsks[index]
+                let target = OverlayButtonTarget { onSelectExternalAsk(action) }
+                buttonTargets.append(target)
+                content.addSubview(makeActionButton(
                     frame: frame,
                     title: action.displayName,
                     symbolName: action.symbolName,
@@ -119,7 +89,7 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
                     ),
                     accessibilityLabel: L10n.string("selection.actionBar.externalAskAccessibility", action.displayName),
                     target: target
-                )
+                ))
             }
         }
 
@@ -329,6 +299,19 @@ private final class OverlayButtonTarget: NSObject {
     }
 }
 
+enum SelectionActionBarPlacedItem: Equatable {
+    case preset(index: Int, frame: NSRect)
+    case divider(frame: NSRect)
+    case externalAsk(index: Int, frame: NSRect)
+
+    var frame: NSRect {
+        switch self {
+        case let .preset(_, frame), let .divider(frame), let .externalAsk(_, frame):
+            return frame
+        }
+    }
+}
+
 struct SelectionActionBarLayout: Equatable {
     static let maxTotalActions = 8
     static let maxTotalWidth: CGFloat = 400
@@ -353,6 +336,36 @@ struct SelectionActionBarLayout: Equatable {
     var visibleExternalAskWidths: [CGFloat]
     var showsDivider: Bool
     var size: NSSize
+
+    var placedItems: [SelectionActionBarPlacedItem] {
+        var x = Self.contentInset
+        var items: [SelectionActionBarPlacedItem] = []
+        let buttonY = Self.contentInset
+        let buttonHeight = Self.controlSize.height
+
+        for (index, width) in visiblePresetWidths.enumerated() {
+            if index > 0 { x += Self.controlSpacing }
+            items.append(.preset(index: index, frame: NSRect(x: x, y: buttonY, width: width, height: buttonHeight)))
+            x += width
+        }
+        if showsDivider {
+            x += Self.dividerMargin
+            items.append(.divider(frame: NSRect(
+                x: x,
+                y: (size.height - Self.dividerHeight) / 2,
+                width: Self.dividerWidth,
+                height: Self.dividerHeight
+            )))
+            x += Self.dividerWidth + Self.dividerMargin
+        }
+        for (index, width) in visibleExternalAskWidths.enumerated() {
+            if index > 0 { x += Self.controlSpacing }
+            items.append(.externalAsk(index: index, frame: NSRect(x: x, y: buttonY, width: width, height: buttonHeight)))
+            x += width
+        }
+        return items
+    }
+
 
     static func buttonWidth(for title: String) -> CGFloat {
         let textWidth = (title as NSString).size(
@@ -401,83 +414,112 @@ struct SelectionActionBarLayout: Equatable {
             )
         }
 
-        let presetWidths = cappedPresets.map { buttonWidth(for: $0.title) }
-        let pGroupWidth: CGFloat
-        if presetWidths.isEmpty {
-            pGroupWidth = 0
-        } else {
-            pGroupWidth = presetWidths.reduce(0, +) + CGFloat(presetWidths.count - 1) * controlSpacing
+        // Keep every retained prompt. Drop trailing External Ask first; if the
+        // remaining prompts still overflow 400pt, truncate button titles so
+        // every control stays inside the panel and clickable. Full names stay
+        // on the tooltip.
+        let presetNaturalWidths = cappedPresets.map { buttonWidth(for: $0.title) }
+        var chosenExternalAsks = cappedExternalAsks
+
+        func groupWidth(_ widths: [CGFloat]) -> CGFloat {
+            guard !widths.isEmpty else { return 0 }
+            return widths.reduce(0, +) + CGFloat(widths.count - 1) * controlSpacing
         }
 
-        let hasPresets = !cappedPresets.isEmpty
-        var finalExternalAsks: [QuickAction] = []
-        var finalExternalAskWidths: [CGFloat] = []
+        func labeledWidth(presetWidths: [CGFloat], eaWidths: [CGFloat]) -> CGFloat {
+            let div = (!presetWidths.isEmpty && !eaWidths.isEmpty) ? dividerOccupiedWidth : 0
+            return contentInset * 2 + groupWidth(presetWidths) + div + groupWidth(eaWidths)
+        }
 
-        if !cappedExternalAsks.isEmpty {
-            let availableForEA = maxTotalWidth - (contentInset * 2) - pGroupWidth - (hasPresets ? dividerOccupiedWidth : 0)
-            if availableForEA >= minExternalAskWidth {
-                for k in stride(from: cappedExternalAsks.count, through: 1, by: -1) {
-                    let candidates = Array(cappedExternalAsks.prefix(k))
-                    let naturalWidths = candidates.map { buttonWidth(for: $0.displayName) }
-                    let spacingTotal = CGFloat(k - 1) * controlSpacing
-                    let minRequired = CGFloat(k) * minExternalAskWidth + spacingTotal
-
-                    if availableForEA >= minRequired {
-                        let naturalTotal = naturalWidths.reduce(0, +) + spacingTotal
-                        if naturalTotal <= availableForEA {
-                            finalExternalAsks = candidates
-                            finalExternalAskWidths = naturalWidths
-                            break
-                        } else {
-                            let availableForButtons = availableForEA - spacingTotal
-                            var low: CGFloat = minExternalAskWidth
-                            var high: CGFloat = naturalWidths.max() ?? minExternalAskWidth
-                            var bestCap: CGFloat = minExternalAskWidth
-                            for _ in 0..<15 {
-                                let mid = (low + high) / 2
-                                let sum = naturalWidths.map { min($0, mid) }.reduce(0, +)
-                                if sum <= availableForButtons {
-                                    bestCap = mid
-                                    low = mid
-                                } else {
-                                    high = mid
-                                }
-                            }
-                            finalExternalAsks = candidates
-                            finalExternalAskWidths = naturalWidths.map { floor(min($0, bestCap)) }
-                            break
-                        }
-                    }
-                }
+        while !chosenExternalAsks.isEmpty {
+            let minEAWidths = Array(repeating: minExternalAskWidth, count: chosenExternalAsks.count)
+            if labeledWidth(presetWidths: presetNaturalWidths, eaWidths: minEAWidths) <= maxTotalWidth {
+                break
             }
+            chosenExternalAsks.removeLast()
         }
 
-        let showsDivider = !cappedPresets.isEmpty && !finalExternalAsks.isEmpty
-        let eaGroupWidth: CGFloat
-        if finalExternalAskWidths.isEmpty {
-            eaGroupWidth = 0
+        let showsDivider = !cappedPresets.isEmpty && !chosenExternalAsks.isEmpty
+        let presetSpacing = cappedPresets.count > 1 ? CGFloat(cappedPresets.count - 1) * controlSpacing : 0
+        let eaSpacing = chosenExternalAsks.count > 1 ? CGFloat(chosenExternalAsks.count - 1) * controlSpacing : 0
+        let presetWidths: [CGFloat]
+        let eaWidths: [CGFloat]
+
+        if chosenExternalAsks.isEmpty {
+            let available = max(0, maxTotalWidth - contentInset * 2 - presetSpacing)
+            presetWidths = compressedWidths(presetNaturalWidths, into: available)
+            eaWidths = []
         } else {
-            eaGroupWidth = finalExternalAskWidths.reduce(0, +) + CGFloat(finalExternalAskWidths.count - 1) * controlSpacing
+            presetWidths = presetNaturalWidths
+            let availableEA = max(
+                0,
+                maxTotalWidth - contentInset * 2 - groupWidth(presetNaturalWidths) - dividerOccupiedWidth - eaSpacing
+            )
+            eaWidths = compressedWidths(
+                chosenExternalAsks.map { buttonWidth(for: $0.displayName) },
+                into: availableEA
+            )
         }
 
-        var totalWidth = contentInset * 2 + pGroupWidth
-        if showsDivider {
-            totalWidth += dividerOccupiedWidth + eaGroupWidth
-        } else {
-            totalWidth += eaGroupWidth
-        }
-
+        let totalWidth = labeledWidth(presetWidths: presetWidths, eaWidths: eaWidths)
         return SelectionActionBarLayout(
             visiblePresets: cappedPresets,
             visiblePresetWidths: presetWidths,
-            visibleExternalAsks: finalExternalAsks,
-            visibleExternalAskWidths: finalExternalAskWidths,
+            visibleExternalAsks: chosenExternalAsks,
+            visibleExternalAskWidths: eaWidths,
             showsDivider: showsDivider,
             size: NSSize(
-                width: max(minimumSize.width, min(maxTotalWidth, totalWidth)),
+                width: max(minimumSize.width, totalWidth),
                 height: max(minimumSize.height, controlSize.height + contentInset * 2)
             )
         )
+    }
+
+    /// Caps the longest titles first so every remaining button fits `available`.
+    /// Never drops items. Short titles keep their natural width.
+    static func compressedWidths(
+        _ natural: [CGFloat],
+        into available: CGFloat
+    ) -> [CGFloat] {
+        guard !natural.isEmpty else { return [] }
+        if natural.reduce(0, +) <= available {
+            return natural
+        }
+
+        let equalShare = max(1, floor(available / CGFloat(natural.count)))
+        var low = equalShare
+        var high = max(equalShare, natural.max() ?? equalShare)
+        var bestCap = equalShare
+        for _ in 0..<20 {
+            let mid = (low + high) / 2
+            let sum = natural.map { min($0, mid) }.reduce(0, +)
+            if sum <= available {
+                bestCap = mid
+                low = mid
+            } else {
+                high = mid
+            }
+        }
+
+        var widths = natural.map { floor(min($0, max(1, bestCap))) }
+        var leftover = floor(available) - widths.reduce(0, +)
+        if leftover > 0 {
+            for index in widths.indices {
+                let extra = min(natural[index] - widths[index], leftover)
+                widths[index] += extra
+                leftover -= extra
+                if leftover <= 0 { break }
+            }
+        } else if leftover < 0 {
+            for index in widths.indices.reversed() {
+                let reducible = max(0, widths[index] - 1)
+                let take = min(reducible, -leftover)
+                widths[index] -= take
+                leftover += take
+                if leftover >= 0 { break }
+            }
+        }
+        return widths
     }
 }
 

--- a/Sources/SpotAsk/Selection/SelectionOverlayController.swift
+++ b/Sources/SpotAsk/Selection/SelectionOverlayController.swift
@@ -330,8 +330,7 @@ private final class OverlayButtonTarget: NSObject {
 }
 
 struct SelectionActionBarLayout: Equatable {
-    static let maxPresets = 4
-    static let maxExternalAsks = 3
+    static let maxTotalActions = 6
     static let maxTotalWidth: CGFloat = 400
     static let minExternalAskWidth: CGFloat = 48
     static let controlSize = NSSize(width: 28, height: 28)
@@ -373,8 +372,9 @@ struct SelectionActionBarLayout: Equatable {
         externalAsks: [QuickAction],
         showsLabels: Bool
     ) -> SelectionActionBarLayout {
-        let cappedPresets = Array(presets.prefix(maxPresets))
-        let cappedExternalAsks = Array(externalAsks.prefix(maxExternalAsks))
+        let cappedPresets = Array(presets.prefix(maxTotalActions))
+        let remainingSlots = max(0, maxTotalActions - cappedPresets.count)
+        let cappedExternalAsks = Array(externalAsks.prefix(remainingSlots))
 
         if !showsLabels {
             var chosenExternalAsks = cappedExternalAsks

--- a/Sources/SpotAsk/Selection/SelectionOverlayController.swift
+++ b/Sources/SpotAsk/Selection/SelectionOverlayController.swift
@@ -2,59 +2,152 @@ import AppKit
 
 @MainActor
 final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
-    private static let controlSize = NSSize(width: 28, height: 28)
-    private static let contentInset: CGFloat = 4
-    private static let controlSpacing: CGFloat = 2
-    private static let labelFontSize: CGFloat = 12
-
     private var panel: NSPanel?
     private var dismissWorkItem: DispatchWorkItem?
     private var buttonTargets: [OverlayButtonTarget] = []
     private var globalMouseMonitor: Any?
     private var localMouseMonitor: Any?
+    private var isPresentingMenu = false
+    private var overflowPresets: [PromptPreset] = []
+    private var overflowQuickActions: [QuickAction] = []
+    private var presetShortcut: ((PromptPreset) -> InAppShortcut?)?
+    private var actionShortcut: ((QuickAction) -> InAppShortcut?)?
+    private var selectPreset: ((PromptPreset) -> Void)?
+    private var selectQuickAction: ((QuickAction) -> Void)?
 
     func showActions(
         snapshot: SelectedTextSnapshot,
         presets: [PromptPreset],
+        quickActions: [QuickAction],
         showsLabels: Bool,
-        onSelect: @escaping (PromptPreset) -> Void
+        shortcutForPreset: @escaping (PromptPreset) -> InAppShortcut?,
+        shortcutForAction: @escaping (QuickAction) -> InAppShortcut?,
+        onSelect: @escaping (PromptPreset) -> Void,
+        onSelectQuickAction: @escaping (QuickAction) -> Void
     ) {
-        let size = actionBarSize(for: presets, showsLabels: showsLabels)
+        let layout = SelectionActionBarLayout.make(
+            presets: presets,
+            quickActions: quickActions,
+            showsLabels: showsLabels
+        )
+        overflowPresets = layout.overflowPresets
+        overflowQuickActions = layout.overflowQuickActions
+        presetShortcut = shortcutForPreset
+        actionShortcut = shortcutForAction
+        selectPreset = onSelect
+        selectQuickAction = onSelectQuickAction
+
+        let size = layout.size
         let content = makeContainer(size: size)
-        var cursorX = Self.contentInset
-        buttonTargets = presets.map { preset in
-            let target = OverlayButtonTarget { onSelect(preset) }
-            let width = showsLabels ? Self.actionButtonWidth(for: preset.title) : Self.controlSize.width
-            let button = NSButton(frame: NSRect(
+        var cursorX = SelectionActionBarLayout.contentInset
+        buttonTargets = []
+
+        func placeButton(width: CGFloat, configure: (NSRect) -> NSButton) {
+            let frame = NSRect(
                 x: cursorX,
-                y: Self.contentInset,
+                y: SelectionActionBarLayout.contentInset,
                 width: width,
-                height: Self.controlSize.height
-            ))
-            cursorX += width + Self.controlSpacing
-            if let image = NSImage(systemSymbolName: preset.symbolName, accessibilityDescription: preset.title) {
-                button.image = image.withSymbolConfiguration(.init(pointSize: showsLabels ? 13 : 15, weight: .regular))
-            }
-            if showsLabels {
-                button.title = preset.title
-                button.font = .systemFont(ofSize: Self.labelFontSize)
-                button.imagePosition = .imageLeading
-                button.imageHugsTitle = true
-                button.alignment = .left
-            } else {
-                button.imagePosition = .imageOnly
-            }
-            button.isBordered = false
-            button.contentTintColor = .labelColor
-            button.toolTip = preset.title
-            button.target = target
-            button.action = #selector(OverlayButtonTarget.invoke)
-            button.setAccessibilityLabel(preset.title)
-            content.addSubview(button)
-            return target
+                height: SelectionActionBarLayout.controlSize.height
+            )
+            content.addSubview(configure(frame))
+            cursorX += width
         }
+
+        func placeGroupSpacing() {
+            cursorX += SelectionActionBarLayout.controlSpacing
+        }
+
+        for (index, preset) in layout.visiblePresets.enumerated() {
+            if index > 0 { placeGroupSpacing() }
+            let width = SelectionActionBarLayout.buttonWidth(for: preset.title, showsLabels: showsLabels)
+            let target = OverlayButtonTarget { onSelect(preset) }
+            buttonTargets.append(target)
+            placeButton(width: width) { frame in
+                makeActionButton(
+                    frame: frame,
+                    title: preset.title,
+                    symbolName: preset.symbolName,
+                    brandSlug: nil,
+                    showsLabels: showsLabels,
+                    toolTip: SelectionActionBarLayout.tooltip(
+                        name: preset.title,
+                        kind: nil,
+                        shortcut: shortcutForPreset(preset)
+                    ),
+                    accessibilityLabel: preset.title,
+                    target: target
+                )
+            }
+        }
+
+        if layout.showsSeparator {
+            cursorX += SelectionActionBarLayout.separatorMargin
+            let separator = NSView(frame: NSRect(
+                x: cursorX,
+                y: (size.height - SelectionActionBarLayout.separatorHeight) / 2,
+                width: SelectionActionBarLayout.separatorWidth,
+                height: SelectionActionBarLayout.separatorHeight
+            ))
+            separator.wantsLayer = true
+            separator.layer?.backgroundColor = NSColor.separatorColor.cgColor
+            separator.setAccessibilityElement(false)
+            content.addSubview(separator)
+            cursorX += SelectionActionBarLayout.separatorWidth + SelectionActionBarLayout.separatorMargin
+        } else if layout.showsMore, !layout.visiblePresets.isEmpty {
+            placeGroupSpacing()
+        }
+
+        for (index, action) in layout.visibleQuickActions.enumerated() {
+            if index > 0 { placeGroupSpacing() }
+            let width = SelectionActionBarLayout.buttonWidth(for: action.displayName, showsLabels: showsLabels)
+            let target = OverlayButtonTarget { onSelectQuickAction(action) }
+            buttonTargets.append(target)
+            placeButton(width: width) { frame in
+                makeActionButton(
+                    frame: frame,
+                    title: action.displayName,
+                    symbolName: action.symbolName,
+                    brandSlug: action.brandIconSlug,
+                    showsLabels: showsLabels,
+                    toolTip: SelectionActionBarLayout.tooltip(
+                        name: action.displayName,
+                        kind: SelectionActionBarLayout.kindLabel(for: action.kind),
+                        shortcut: shortcutForAction(action)
+                    ),
+                    accessibilityLabel: L10n.string("selection.actionBar.externalAskAccessibility", action.displayName),
+                    target: target
+                )
+            }
+        }
+
+        if layout.showsMore {
+            if layout.showsSeparator || !layout.visibleQuickActions.isEmpty {
+                if !layout.visibleQuickActions.isEmpty { placeGroupSpacing() }
+            }
+            let moreTitle = L10n.string("selection.actionBar.more")
+            let width = SelectionActionBarLayout.buttonWidth(for: moreTitle, showsLabels: showsLabels)
+            let target = OverlayButtonTarget { [weak self] in
+                self?.presentOverflowMenu()
+            }
+            buttonTargets.append(target)
+            placeButton(width: width) { frame in
+                let button = makeActionButton(
+                    frame: frame,
+                    title: moreTitle,
+                    symbolName: "ellipsis",
+                    brandSlug: nil,
+                    showsLabels: showsLabels,
+                    toolTip: moreTitle,
+                    accessibilityLabel: L10n.string("selection.actionBar.moreAccessibility"),
+                    target: target
+                )
+                button.identifier = NSUserInterfaceItemIdentifier("selection.actionBar.more")
+                return button
+            }
+        }
+
         present(content: content, size: size, anchor: snapshot.anchor)
-        scheduleDismiss(after: 8)
+        scheduleDismiss(after: SelectionActionBarLayout.actionBarDismissDelay)
     }
 
     func showMessage(_ message: SelectionFeedback) {
@@ -95,6 +188,13 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
         dismissWorkItem?.cancel()
         dismissWorkItem = nil
         buttonTargets.removeAll()
+        overflowPresets = []
+        overflowQuickActions = []
+        presetShortcut = nil
+        actionShortcut = nil
+        selectPreset = nil
+        selectQuickAction = nil
+        isPresentingMenu = false
         endOutsideClickMonitoring()
         panel?.orderOut(nil)
         panel = nil
@@ -143,22 +243,117 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
         return label
     }
 
-    private func actionBarSize(for presets: [PromptPreset], showsLabels: Bool) -> NSSize {
-        let widths = presets.map { showsLabels ? Self.actionButtonWidth(for: $0.title) : Self.controlSize.width }
-        let controlsWidth = widths.reduce(0, +)
-        let spacingWidth = CGFloat(max(0, widths.count - 1)) * Self.controlSpacing
-        return NSSize(
-            width: max(44, controlsWidth + spacingWidth + Self.contentInset * 2),
-            height: Self.controlSize.height + Self.contentInset * 2
-        )
+    private func makeActionButton(
+        frame: NSRect,
+        title: String,
+        symbolName: String,
+        brandSlug: String?,
+        showsLabels: Bool,
+        toolTip: String,
+        accessibilityLabel: String,
+        target: OverlayButtonTarget
+    ) -> OverlayHoverButton {
+        let iconPointSize = showsLabels
+            ? SelectionActionBarLayout.labeledIconSize
+            : SelectionActionBarLayout.compactIconSize
+        let button = OverlayHoverButton(frame: frame)
+        button.iconPointSize = iconPointSize
+        button.symbolName = symbolName
+        button.brandImage = brandImage(for: brandSlug)
+        button.applyRestingIcon()
+        if showsLabels {
+            button.title = title
+            button.font = .systemFont(ofSize: SelectionActionBarLayout.labelFontSize)
+            button.imagePosition = .imageLeading
+            button.imageHugsTitle = true
+            button.alignment = .left
+        } else {
+            button.title = ""
+            button.imagePosition = .imageOnly
+        }
+        button.isBordered = false
+        button.contentTintColor = .labelColor
+        button.toolTip = toolTip
+        button.target = target
+        button.action = #selector(OverlayButtonTarget.invoke)
+        button.setAccessibilityLabel(accessibilityLabel)
+        return button
     }
 
-    private static func actionButtonWidth(for title: String) -> CGFloat {
-        let textWidth = (title as NSString).size(
-            withAttributes: [.font: NSFont.systemFont(ofSize: labelFontSize)]
-        ).width
-        // image + image-to-title gap + leading/trailing padding
-        return ceil(textWidth) + 13 + 4 + 10
+    private func brandImage(for slug: String?) -> NSImage? {
+        guard let slug else { return nil }
+        let dark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        guard let image = ProviderBrandIcon.image(for: slug, dark: dark) else { return nil }
+        image.isTemplate = false
+        return image
+    }
+
+    private func presentOverflowMenu() {
+        guard let moreButton = moreButton() else { return }
+        dismissWorkItem?.cancel()
+        dismissWorkItem = nil
+        isPresentingMenu = true
+
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        for preset in overflowPresets {
+            menu.addItem(menuItem(
+                title: preset.title,
+                symbolName: preset.symbolName,
+                brandSlug: nil,
+                shortcut: presetShortcut?(preset)
+            ) { [weak self] in
+                self?.selectPreset?(preset)
+            })
+        }
+        for action in overflowQuickActions {
+            menu.addItem(menuItem(
+                title: action.displayName,
+                symbolName: action.symbolName,
+                brandSlug: action.brandIconSlug,
+                shortcut: actionShortcut?(action)
+            ) { [weak self] in
+                self?.selectQuickAction?(action)
+            })
+        }
+
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: 0), in: moreButton)
+        isPresentingMenu = false
+        if panel != nil {
+            scheduleDismiss(after: SelectionActionBarLayout.actionBarDismissDelay)
+        }
+    }
+
+    private func menuItem(
+        title: String,
+        symbolName: String,
+        brandSlug: String?,
+        shortcut: InAppShortcut?,
+        handler: @escaping () -> Void
+    ) -> NSMenuItem {
+        let target = OverlayButtonTarget(handler: handler)
+        buttonTargets.append(target)
+        let item = NSMenuItem(title: title, action: #selector(OverlayButtonTarget.invoke), keyEquivalent: "")
+        item.target = target
+        item.isEnabled = true
+        if let brand = brandImage(for: brandSlug) {
+            let icon = brand.copy() as? NSImage ?? brand
+            icon.size = NSSize(width: 16, height: 16)
+            icon.isTemplate = false
+            item.image = icon
+        } else {
+            item.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: title)?
+                .withSymbolConfiguration(.init(pointSize: 13, weight: .regular))
+        }
+        if let shortcut {
+            item.keyEquivalent = shortcut.key == " " ? " " : shortcut.key.lowercased()
+            item.keyEquivalentModifierMask = shortcut.modifierFlags
+        }
+        return item
+    }
+
+    private func moreButton() -> NSView? {
+        panel?.contentView?.subviews.first { $0.identifier?.rawValue == "selection.actionBar.more" }
     }
 
     private func makePanel(size: NSSize) -> NSPanel {
@@ -197,7 +392,7 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
     }
 
     private func dismissForOutsideClickIfNeeded() {
-        guard let panel, !panel.frame.contains(NSEvent.mouseLocation) else { return }
+        guard !isPresentingMenu, let panel, !panel.frame.contains(NSEvent.mouseLocation) else { return }
         hide()
     }
 
@@ -211,7 +406,6 @@ final class SelectionOverlayController: NSObject, SelectionOverlayControlling {
         guard let visible = screen?.visibleFrame else { return point }
         return NSPoint(x: min(max(point.x, visible.minX + 8), visible.maxX - size.width - 8), y: min(max(point.y, visible.minY + 8), visible.maxY - size.height - 8))
     }
-
 }
 
 private final class OverlayButtonTarget: NSObject {
@@ -223,6 +417,243 @@ private final class OverlayButtonTarget: NSObject {
 
     @objc func invoke() {
         handler()
+    }
+}
+
+private final class OverlayHoverButton: NSButton {
+    var iconPointSize: CGFloat = SelectionActionBarLayout.compactIconSize
+    var symbolName: String?
+    var brandImage: NSImage?
+    private var hoverTrackingArea: NSTrackingArea?
+    private let hoverFill = CALayer()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        hoverFill.cornerRadius = SelectionActionBarLayout.hoverCornerRadius
+        hoverFill.backgroundColor = NSColor.labelColor.withAlphaComponent(SelectionActionBarLayout.hoverFillOpacity).cgColor
+        hoverFill.opacity = 0
+        layer?.insertSublayer(hoverFill, at: 0)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layout() {
+        super.layout()
+        hoverFill.frame = bounds
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let hoverTrackingArea {
+            removeTrackingArea(hoverTrackingArea)
+        }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        hoverTrackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        setHovering(true)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        setHovering(false)
+    }
+
+    func applyRestingIcon() {
+        applyIcon(pointSize: iconPointSize)
+    }
+
+    private func setHovering(_ hovering: Bool) {
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = SelectionActionBarLayout.hoverDuration
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            hoverFill.opacity = hovering ? 1 : 0
+        }
+        applyIcon(pointSize: hovering ? iconPointSize * SelectionActionBarLayout.hoverScale : iconPointSize)
+    }
+
+    private func applyIcon(pointSize: CGFloat) {
+        if let brandImage {
+            let icon = brandImage.copy() as? NSImage ?? brandImage
+            icon.size = NSSize(width: pointSize, height: pointSize)
+            icon.isTemplate = false
+            image = icon
+            return
+        }
+        guard let symbolName,
+              let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: title.isEmpty ? nil : title)
+        else { return }
+        image = symbol.withSymbolConfiguration(.init(pointSize: pointSize, weight: .regular))
+    }
+}
+
+struct SelectionActionBarLayout: Equatable {
+    static let maxVisiblePerGroup = 4
+    static let maxLabeledWidth: CGFloat = 480
+    static let controlSize = NSSize(width: 28, height: 28)
+    static let contentInset: CGFloat = 4
+    static let controlSpacing: CGFloat = 2
+    static let separatorWidth: CGFloat = 1
+    static let separatorHeight: CGFloat = 20
+    static let separatorMargin: CGFloat = 6
+    static let separatorOccupiedWidth: CGFloat = separatorWidth + separatorMargin * 2
+    static let labelFontSize: CGFloat = 12
+    static let compactIconSize: CGFloat = 15
+    static let labeledIconSize: CGFloat = 13
+    static let hoverScale: CGFloat = 1.1
+    static let hoverDuration: TimeInterval = 0.12
+    static let hoverCornerRadius: CGFloat = 6
+    static let hoverFillOpacity: CGFloat = 0.08
+    static let actionBarDismissDelay: TimeInterval = 8
+    static let minimumSize = NSSize(width: 44, height: 36)
+
+    var visiblePresets: [PromptPreset]
+    var visibleQuickActions: [QuickAction]
+    var overflowPresets: [PromptPreset]
+    var overflowQuickActions: [QuickAction]
+    var showsSeparator: Bool
+    var showsMore: Bool
+    var size: NSSize
+
+    static func make(
+        presets: [PromptPreset],
+        quickActions: [QuickAction],
+        showsLabels: Bool,
+        moreTitle: String = L10n.string("selection.actionBar.more")
+    ) -> SelectionActionBarLayout {
+        var visiblePresets = Array(presets.prefix(maxVisiblePerGroup))
+        var overflowPresets = Array(presets.dropFirst(maxVisiblePerGroup))
+        var visibleQuickActions = Array(quickActions.prefix(maxVisiblePerGroup))
+        var overflowQuickActions = Array(quickActions.dropFirst(maxVisiblePerGroup))
+
+        func current() -> SelectionActionBarLayout {
+            let showsMore = !overflowPresets.isEmpty || !overflowQuickActions.isEmpty
+            let moreOnTrailingGroup = !quickActions.isEmpty
+            let leadingHasContent = !visiblePresets.isEmpty || (showsMore && !moreOnTrailingGroup)
+            let trailingHasContent = !visibleQuickActions.isEmpty || (showsMore && moreOnTrailingGroup)
+            let showsSeparator = leadingHasContent && trailingHasContent
+            let size = barSize(
+                visiblePresets: visiblePresets,
+                visibleQuickActions: visibleQuickActions,
+                showsSeparator: showsSeparator,
+                showsMore: showsMore,
+                moreOnTrailingGroup: moreOnTrailingGroup,
+                showsLabels: showsLabels,
+                moreTitle: moreTitle
+            )
+            return SelectionActionBarLayout(
+                visiblePresets: visiblePresets,
+                visibleQuickActions: visibleQuickActions,
+                overflowPresets: overflowPresets,
+                overflowQuickActions: overflowQuickActions,
+                showsSeparator: showsSeparator,
+                showsMore: showsMore,
+                size: size
+            )
+        }
+
+        var layout = current()
+        if showsLabels {
+            while layout.size.width > maxLabeledWidth {
+                if !visibleQuickActions.isEmpty {
+                    overflowQuickActions.insert(visibleQuickActions.removeLast(), at: 0)
+                } else if !visiblePresets.isEmpty {
+                    overflowPresets.insert(visiblePresets.removeLast(), at: 0)
+                } else {
+                    break
+                }
+                layout = current()
+            }
+        }
+        return layout
+    }
+
+    static func buttonWidth(for title: String, showsLabels: Bool) -> CGFloat {
+        showsLabels ? actionButtonWidth(for: title) : controlSize.width
+    }
+
+    static func actionButtonWidth(for title: String) -> CGFloat {
+        let textWidth = (title as NSString).size(
+            withAttributes: [.font: NSFont.systemFont(ofSize: labelFontSize)]
+        ).width
+        return ceil(textWidth) + 13 + 4 + 10
+    }
+
+    static func kindLabel(for kind: QuickActionKind) -> String {
+        switch kind {
+        case .web: L10n.string("selection.actionBar.kind.web")
+        case .uriScheme: L10n.string("selection.actionBar.kind.uriScheme")
+        case .terminal: L10n.string("selection.actionBar.kind.terminal")
+        }
+    }
+
+    static func tooltip(name: String, kind: String?, shortcut: InAppShortcut?) -> String {
+        var text = name
+        if let kind {
+            text += " — \(kind)"
+        }
+        if let shortcut {
+            text += "（\(InAppShortcutDisplay.labels(for: shortcut).joined())）"
+        }
+        return text
+    }
+
+    private static func barSize(
+        visiblePresets: [PromptPreset],
+        visibleQuickActions: [QuickAction],
+        showsSeparator: Bool,
+        showsMore: Bool,
+        moreOnTrailingGroup: Bool,
+        showsLabels: Bool,
+        moreTitle: String
+    ) -> NSSize {
+        let moreWidth = showsMore ? buttonWidth(for: moreTitle, showsLabels: showsLabels) : nil
+        var leading = visiblePresets.map { buttonWidth(for: $0.title, showsLabels: showsLabels) }
+        var trailing = visibleQuickActions.map { buttonWidth(for: $0.displayName, showsLabels: showsLabels) }
+        if let moreWidth {
+            if moreOnTrailingGroup {
+                trailing.append(moreWidth)
+            } else {
+                leading.append(moreWidth)
+            }
+        }
+
+        var width = contentInset * 2 + groupWidth(leading)
+        if showsSeparator {
+            width += separatorOccupiedWidth + groupWidth(trailing)
+        } else {
+            width += groupWidth(trailing)
+        }
+        return NSSize(
+            width: max(minimumSize.width, width),
+            height: max(minimumSize.height, controlSize.height + contentInset * 2)
+        )
+    }
+
+    private static func groupWidth(_ widths: [CGFloat]) -> CGFloat {
+        guard !widths.isEmpty else { return 0 }
+        return widths.reduce(0, +) + CGFloat(widths.count - 1) * controlSpacing
+    }
+}
+
+private extension InAppShortcut {
+    var modifierFlags: NSEvent.ModifierFlags {
+        var mask: NSEvent.ModifierFlags = []
+        if modifiers.contains(.command) { mask.insert(.command) }
+        if modifiers.contains(.shift) { mask.insert(.shift) }
+        if modifiers.contains(.option) { mask.insert(.option) }
+        if modifiers.contains(.control) { mask.insert(.control) }
+        return mask
     }
 }
 

--- a/Sources/SpotAsk/Settings/AppSettings.swift
+++ b/Sources/SpotAsk/Settings/AppSettings.swift
@@ -348,6 +348,7 @@ final class AppSettings {
         static let selectionAutoInvokeBlacklist = "selectionAutoInvokeBlacklist"
         static let selectionAutoInvokeWhitelist = "selectionAutoInvokeWhitelist"
         static let selectionActionBarShowsLabels = "selectionActionBarShowsLabels"
+        static let selectionActionBarShowsPrompts = "selectionActionBarShowsPrompts"
         static let selectionActionBarShowsExternalAsk = "selectionActionBarShowsExternalAsk"
         static let automaticUpdateCheckEnabled = "automaticUpdateCheckEnabled"
         static let quickActionCatalog = "webQuickAskProviderCatalog"
@@ -441,6 +442,7 @@ final class AppSettings {
         }
     }
     var selectionActionBarShowsLabels: Bool { didSet { defaults.set(selectionActionBarShowsLabels, forKey: Key.selectionActionBarShowsLabels) } }
+    var selectionActionBarShowsPrompts: Bool { didSet { defaults.set(selectionActionBarShowsPrompts, forKey: Key.selectionActionBarShowsPrompts) } }
     var selectionActionBarShowsExternalAsk: Bool { didSet { defaults.set(selectionActionBarShowsExternalAsk, forKey: Key.selectionActionBarShowsExternalAsk) } }
     var automaticUpdateCheckEnabled: Bool {
         didSet { defaults.set(automaticUpdateCheckEnabled, forKey: Key.automaticUpdateCheckEnabled) }
@@ -607,6 +609,7 @@ final class AppSettings {
         selectionAutoInvokeBlacklist = defaults.stringArray(forKey: Key.selectionAutoInvokeBlacklist) ?? []
         selectionAutoInvokeWhitelist = defaults.stringArray(forKey: Key.selectionAutoInvokeWhitelist) ?? []
         selectionActionBarShowsLabels = defaults.object(forKey: Key.selectionActionBarShowsLabels) as? Bool ?? true
+        selectionActionBarShowsPrompts = defaults.object(forKey: Key.selectionActionBarShowsPrompts) as? Bool ?? true
         selectionActionBarShowsExternalAsk = defaults.object(forKey: Key.selectionActionBarShowsExternalAsk) as? Bool ?? true
         automaticUpdateCheckEnabled = defaults.object(forKey: Key.automaticUpdateCheckEnabled) as? Bool ?? true
         selectionAutoInvokeDelay = SelectionAutoInvokeDelay.normalized(

--- a/Sources/SpotAsk/Settings/AppSettings.swift
+++ b/Sources/SpotAsk/Settings/AppSettings.swift
@@ -348,6 +348,7 @@ final class AppSettings {
         static let selectionAutoInvokeBlacklist = "selectionAutoInvokeBlacklist"
         static let selectionAutoInvokeWhitelist = "selectionAutoInvokeWhitelist"
         static let selectionActionBarShowsLabels = "selectionActionBarShowsLabels"
+        static let selectionActionBarShowsExternalAsk = "selectionActionBarShowsExternalAsk"
         static let automaticUpdateCheckEnabled = "automaticUpdateCheckEnabled"
         static let quickActionCatalog = "webQuickAskProviderCatalog"
         static let externalAskEnabled = "webQuickAskEnabled"
@@ -440,6 +441,7 @@ final class AppSettings {
         }
     }
     var selectionActionBarShowsLabels: Bool { didSet { defaults.set(selectionActionBarShowsLabels, forKey: Key.selectionActionBarShowsLabels) } }
+    var selectionActionBarShowsExternalAsk: Bool { didSet { defaults.set(selectionActionBarShowsExternalAsk, forKey: Key.selectionActionBarShowsExternalAsk) } }
     var automaticUpdateCheckEnabled: Bool {
         didSet { defaults.set(automaticUpdateCheckEnabled, forKey: Key.automaticUpdateCheckEnabled) }
     }
@@ -605,6 +607,7 @@ final class AppSettings {
         selectionAutoInvokeBlacklist = defaults.stringArray(forKey: Key.selectionAutoInvokeBlacklist) ?? []
         selectionAutoInvokeWhitelist = defaults.stringArray(forKey: Key.selectionAutoInvokeWhitelist) ?? []
         selectionActionBarShowsLabels = defaults.object(forKey: Key.selectionActionBarShowsLabels) as? Bool ?? true
+        selectionActionBarShowsExternalAsk = defaults.object(forKey: Key.selectionActionBarShowsExternalAsk) as? Bool ?? true
         automaticUpdateCheckEnabled = defaults.object(forKey: Key.automaticUpdateCheckEnabled) as? Bool ?? true
         selectionAutoInvokeDelay = SelectionAutoInvokeDelay.normalized(
             defaults.object(forKey: Key.selectionAutoInvokeDelay) as? Double ?? SelectionAutoInvokeDelay.defaultValue

--- a/Sources/SpotAsk/Settings/SelectionAssistantSettingsPage.swift
+++ b/Sources/SpotAsk/Settings/SelectionAssistantSettingsPage.swift
@@ -52,9 +52,18 @@ struct SelectionAssistantSettingsPage: View {
                         SettingsToggleRow(label: L10n.string("settings.selectionAssistantAutoShow"), isOn: Bindable(settings).selectionAutoInvokeEnabled)
                         SettingsToggleRow(label: L10n.string("settings.selectionAssistantActionLabels"), isOn: Bindable(settings).selectionActionBarShowsLabels)
                         SettingsToggleRow(
+                            label: L10n.string("settings.selectionAssistantActionPrompts"),
+                            isOn: Bindable(settings).selectionActionBarShowsPrompts
+                        )
+                        SettingsToggleRow(
                             label: L10n.string("settings.selectionAssistantActionExternalAsk"),
                             isOn: Bindable(settings).selectionActionBarShowsExternalAsk
                         )
+                        if showsActionBarCrowdingHint {
+                            Text(L10n.string("settings.selectionAssistantActionBarCrowdingHint"))
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                        }
                         if settings.selectionAutoInvokeEnabled {
                             SettingsFieldRow(label: L10n.string("settings.selectionAssistantAutoShowScope")) {
                                 Picker(L10n.string("settings.selectionAssistantAutoShowScope"), selection: Bindable(settings).selectionAutoInvokeScope) {
@@ -122,6 +131,10 @@ struct SelectionAssistantSettingsPage: View {
         case .needsReauthorization:
             L10n.string("settings.selectionAssistantPermissionNeedsReauthorization")
         }
+    }
+
+    private var showsActionBarCrowdingHint: Bool {
+        settings.enabledPromptPresets.count + settings.enabledQuickActions.count > 4
     }
 
     private var permissionStatusDescription: String {

--- a/Sources/SpotAsk/Settings/SelectionAssistantSettingsPage.swift
+++ b/Sources/SpotAsk/Settings/SelectionAssistantSettingsPage.swift
@@ -52,8 +52,7 @@ struct SelectionAssistantSettingsPage: View {
                         SettingsToggleRow(label: L10n.string("settings.selectionAssistantAutoShow"), isOn: Bindable(settings).selectionAutoInvokeEnabled)
                         SettingsToggleRow(label: L10n.string("settings.selectionAssistantActionLabels"), isOn: Bindable(settings).selectionActionBarShowsLabels)
                         SettingsToggleRow(
-                            label: L10n.string("settings.selectionAssistantShowsExternalAsk"),
-                            description: L10n.string("settings.selectionAssistantShowsExternalAskDescription"),
+                            label: L10n.string("settings.selectionAssistantActionExternalAsk"),
                             isOn: Bindable(settings).selectionActionBarShowsExternalAsk
                         )
                         if settings.selectionAutoInvokeEnabled {

--- a/Sources/SpotAsk/Settings/SelectionAssistantSettingsPage.swift
+++ b/Sources/SpotAsk/Settings/SelectionAssistantSettingsPage.swift
@@ -51,6 +51,11 @@ struct SelectionAssistantSettingsPage: View {
                     if settings.selectionAssistantMode == .actionBar {
                         SettingsToggleRow(label: L10n.string("settings.selectionAssistantAutoShow"), isOn: Bindable(settings).selectionAutoInvokeEnabled)
                         SettingsToggleRow(label: L10n.string("settings.selectionAssistantActionLabels"), isOn: Bindable(settings).selectionActionBarShowsLabels)
+                        SettingsToggleRow(
+                            label: L10n.string("settings.selectionAssistantShowsExternalAsk"),
+                            description: L10n.string("settings.selectionAssistantShowsExternalAskDescription"),
+                            isOn: Bindable(settings).selectionActionBarShowsExternalAsk
+                        )
                         if settings.selectionAutoInvokeEnabled {
                             SettingsFieldRow(label: L10n.string("settings.selectionAssistantAutoShowScope")) {
                                 Picker(L10n.string("settings.selectionAssistantAutoShowScope"), selection: Bindable(settings).selectionAutoInvokeScope) {

--- a/Sources/SpotAsk/Settings/SettingsComponents.swift
+++ b/Sources/SpotAsk/Settings/SettingsComponents.swift
@@ -99,21 +99,24 @@ struct SettingsToggleRow: View {
     @Binding var isOn: Bool
 
     var body: some View {
-        SettingsLabeledRow(label: label) {
-            HStack(spacing: 14) {
+        HStack(alignment: .center, spacing: 0) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                    .fixedSize(horizontal: false, vertical: true)
                 if let description {
                     Text(description)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.leading)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
-                Toggle("", isOn: $isOn)
-                    .toggleStyle(.switch)
-                    .labelsHidden()
-                    .accessibilityLabel(label)
             }
-            .frame(maxWidth: .infinity, alignment: .trailing)
+            .layoutPriority(1)
+            Spacer(minLength: 16)
+            Toggle("", isOn: $isOn)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .fixedSize()
+                .accessibilityLabel(label)
         }
     }
 }

--- a/Sources/SpotAsk/Settings/SettingsView.swift
+++ b/Sources/SpotAsk/Settings/SettingsView.swift
@@ -109,12 +109,14 @@ struct SettingsView: View {
                         ExternalAskSettingsPage(settings: settings)
                     }
                 case .selectionAssistant:
-                    SelectionAssistantSettingsPage(
-                        settings: settings,
-                        permissionCoordinator: accessibilityPermissionCoordinator,
-                        settingsOpener: accessibilitySettingsOpener,
-                        onOpenShortcuts: { selectedSection = .shortcuts }
-                    )
+                    ScrollView {
+                        SelectionAssistantSettingsPage(
+                            settings: settings,
+                            permissionCoordinator: accessibilityPermissionCoordinator,
+                            settingsOpener: accessibilitySettingsOpener,
+                            onOpenShortcuts: { selectedSection = .shortcuts }
+                        )
+                    }
                 case .shortcuts:
                     ScrollView {
                         ShortcutSettingsPage(settings: settings)

--- a/Tests/SpotAskTests/AppSettingsTests.swift
+++ b/Tests/SpotAskTests/AppSettingsTests.swift
@@ -75,6 +75,18 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertFalse(AppSettings(defaults: defaults).selectionActionBarShowsExternalAsk)
     }
 
+    func testSelectionActionBarShowsPromptsDefaultsOnAndPersists() {
+        let suite = "AppSettingsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertTrue(AppSettings(defaults: defaults).selectionActionBarShowsPrompts)
+
+        let settings = AppSettings(defaults: defaults)
+        settings.selectionActionBarShowsPrompts = false
+        XCTAssertFalse(AppSettings(defaults: defaults).selectionActionBarShowsPrompts)
+    }
+
     func testProxyDefaultsToOffAndPersists() {
         let suite = "AppSettingsTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!

--- a/Tests/SpotAskTests/AppSettingsTests.swift
+++ b/Tests/SpotAskTests/AppSettingsTests.swift
@@ -63,6 +63,18 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertFalse(AppSettings(defaults: defaults).automaticUpdateCheckEnabled)
     }
 
+    func testSelectionActionBarShowsExternalAskDefaultsOnAndPersists() {
+        let suite = "AppSettingsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertTrue(AppSettings(defaults: defaults).selectionActionBarShowsExternalAsk)
+
+        let settings = AppSettings(defaults: defaults)
+        settings.selectionActionBarShowsExternalAsk = false
+        XCTAssertFalse(AppSettings(defaults: defaults).selectionActionBarShowsExternalAsk)
+    }
+
     func testProxyDefaultsToOffAndPersists() {
         let suite = "AppSettingsTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!

--- a/Tests/SpotAskTests/Selection/SelectionActionBarLayoutTests.swift
+++ b/Tests/SpotAskTests/Selection/SelectionActionBarLayoutTests.swift
@@ -1,0 +1,116 @@
+import AppKit
+import Testing
+@testable import SpotAsk
+
+@Suite("Selection action bar layout")
+struct SelectionActionBarLayoutTests {
+    @Test("Presets only omit the External Ask separator")
+    func presetsOnlyOmitSeparator() {
+        let layout = SelectionActionBarLayout.make(
+            presets: [preset("Translate"), preset("Explain")],
+            quickActions: [],
+            showsLabels: false
+        )
+        #expect(layout.visiblePresets.count == 2)
+        #expect(layout.visibleQuickActions.isEmpty)
+        #expect(!layout.showsSeparator)
+        #expect(!layout.showsMore)
+        #expect(layout.size.width == 8 + 28 + 2 + 28)
+        #expect(layout.size.height == 36)
+    }
+
+    @Test("External Ask actions sit behind a 13pt separator")
+    func compactExternalAskUsesSeparator() {
+        let layout = SelectionActionBarLayout.make(
+            presets: [preset("Translate"), preset("Explain")],
+            quickActions: [action("ChatGPT"), action("Grok"), action("Terminal")],
+            showsLabels: false
+        )
+        #expect(layout.showsSeparator)
+        #expect(!layout.showsMore)
+        #expect(layout.visibleQuickActions.count == 3)
+        #expect(layout.size.width == 8 + 58 + 13 + 88)
+    }
+
+    @Test("A fifth External Ask action folds into More")
+    func fifthQuickActionFoldsIntoMore() {
+        let actions = (1...5).map { action("Action \($0)") }
+        let layout = SelectionActionBarLayout.make(
+            presets: [preset("Translate")],
+            quickActions: actions,
+            showsLabels: false
+        )
+        #expect(layout.visibleQuickActions.map(\.name) == ["Action 1", "Action 2", "Action 3", "Action 4"])
+        #expect(layout.overflowQuickActions.map(\.name) == ["Action 5"])
+        #expect(layout.showsMore)
+        #expect(layout.showsSeparator)
+    }
+
+    @Test("Labeled mode stays at or under 480pt by folding External Ask first")
+    func labeledModeFoldsExternalAskToFit() {
+        let presets = [
+            preset("Translate Selected Text Now"),
+            preset("Explain Selected Text Now"),
+            preset("Summarize Selected Text Now"),
+            preset("Polish Selected Text Now")
+        ]
+        let actions = [
+            action("Ask ChatGPT About This Selection"),
+            action("Ask Grok About This Selection"),
+            action("Open Custom App With Selection"),
+            action("Run Terminal Command With Selection")
+        ]
+        let layout = SelectionActionBarLayout.make(
+            presets: presets,
+            quickActions: actions,
+            showsLabels: true
+        )
+        #expect(layout.size.width <= 480)
+        #expect(layout.visiblePresets.count == 4)
+        #expect(layout.visibleQuickActions.count < 4 || layout.overflowQuickActions.isEmpty)
+        #expect(layout.overflowPresets.isEmpty)
+        #expect(layout.showsMore)
+    }
+
+    @Test("Extreme labeled overflow folds presets only after External Ask is gone")
+    func labeledModeFoldsPresetsAfterExternalAsk() {
+        let presets = (1...4).map { preset(String(repeating: "PresetTitle", count: $0 + 3)) }
+        let actions = (1...4).map { action(String(repeating: "ExternalAskTitle", count: $0 + 3)) }
+        let layout = SelectionActionBarLayout.make(
+            presets: presets,
+            quickActions: actions,
+            showsLabels: true
+        )
+        #expect(layout.size.width <= 480)
+        if !layout.visibleQuickActions.isEmpty {
+            #expect(layout.overflowPresets.isEmpty)
+        }
+    }
+
+    @Test("Tooltips include type and shortcut for External Ask")
+    func tooltipIncludesKindAndShortcut() {
+        let shortcut = InAppShortcut.commandShift("1")
+        #expect(
+            SelectionActionBarLayout.tooltip(
+                name: "Ask ChatGPT",
+                kind: "网页提问",
+                shortcut: shortcut
+            ) == "Ask ChatGPT — 网页提问（⌘⇧1）"
+        )
+        #expect(
+            SelectionActionBarLayout.tooltip(
+                name: "Translate",
+                kind: nil,
+                shortcut: shortcut
+            ) == "Translate（⌘⇧1）"
+        )
+    }
+
+    private func preset(_ title: String) -> PromptPreset {
+        PromptPreset(title: title, instruction: "Do it")
+    }
+
+    private func action(_ name: String) -> QuickAction {
+        QuickAction(name: name, kind: .web(urlTemplate: "https://example.com/?q={query}"))
+    }
+}

--- a/Tests/SpotAskTests/Selection/SelectionActionBarLayoutTests.swift
+++ b/Tests/SpotAskTests/Selection/SelectionActionBarLayoutTests.swift
@@ -33,18 +33,36 @@ struct SelectionActionBarLayoutTests {
         #expect(layout.size.width <= 400)
     }
 
-    @Test("Caps at 4 presets and 3 External Asks")
-    func capsAtFourPresetsAndThreeExternalAsks() {
-        let presets = (1...6).map { preset("Preset \($0)") }
-        let actions = (1...5).map { action("Action \($0)") }
-        let layout = SelectionActionBarLayout.make(
-            presets: presets,
-            externalAsks: actions,
+    @Test("Combined cap is 6 actions and keeps presets over External Ask")
+    func combinedCapKeepsPresetsAndFoldsTrailingExternalAsks() {
+        let sixPresets = (1...8).map { preset("Preset \($0)") }
+        let fiveActions = (1...5).map { action("Action \($0)") }
+        let overflow = SelectionActionBarLayout.make(
+            presets: sixPresets,
+            externalAsks: fiveActions,
             showsLabels: false
         )
-        #expect(layout.visiblePresets.count == 4)
-        #expect(layout.visibleExternalAsks.count == 3)
-        #expect(layout.showsDivider)
+        #expect(overflow.visiblePresets.count == 6)
+        #expect(overflow.visibleExternalAsks.isEmpty)
+        #expect(!overflow.showsDivider)
+
+        let mixed = SelectionActionBarLayout.make(
+            presets: Array(sixPresets.prefix(4)),
+            externalAsks: fiveActions,
+            showsLabels: false
+        )
+        #expect(mixed.visiblePresets.count == 4)
+        #expect(mixed.visibleExternalAsks.count == 2)
+        #expect(mixed.showsDivider)
+
+        let asksOnly = SelectionActionBarLayout.make(
+            presets: [],
+            externalAsks: fiveActions + [action("Action 6"), action("Action 7")],
+            showsLabels: false
+        )
+        #expect(asksOnly.visiblePresets.isEmpty)
+        #expect(asksOnly.visibleExternalAsks.count == 6)
+        #expect(!asksOnly.showsDivider)
     }
 
     @Test("Divider is omitted when presets are empty")

--- a/Tests/SpotAskTests/Selection/SelectionActionBarLayoutTests.swift
+++ b/Tests/SpotAskTests/Selection/SelectionActionBarLayoutTests.swift
@@ -33,35 +33,35 @@ struct SelectionActionBarLayoutTests {
         #expect(layout.size.width <= 400)
     }
 
-    @Test("Combined cap is 6 actions and keeps presets over External Ask")
+    @Test("Combined cap is 8 actions and keeps presets over External Ask")
     func combinedCapKeepsPresetsAndFoldsTrailingExternalAsks() {
-        let sixPresets = (1...8).map { preset("Preset \($0)") }
+        let eightPresets = (1...10).map { preset("Preset \($0)") }
         let fiveActions = (1...5).map { action("Action \($0)") }
         let overflow = SelectionActionBarLayout.make(
-            presets: sixPresets,
+            presets: eightPresets,
             externalAsks: fiveActions,
             showsLabels: false
         )
-        #expect(overflow.visiblePresets.count == 6)
+        #expect(overflow.visiblePresets.count == 8)
         #expect(overflow.visibleExternalAsks.isEmpty)
         #expect(!overflow.showsDivider)
 
         let mixed = SelectionActionBarLayout.make(
-            presets: Array(sixPresets.prefix(4)),
+            presets: Array(eightPresets.prefix(4)),
             externalAsks: fiveActions,
             showsLabels: false
         )
         #expect(mixed.visiblePresets.count == 4)
-        #expect(mixed.visibleExternalAsks.count == 2)
+        #expect(mixed.visibleExternalAsks.count == 4)
         #expect(mixed.showsDivider)
 
         let asksOnly = SelectionActionBarLayout.make(
             presets: [],
-            externalAsks: fiveActions + [action("Action 6"), action("Action 7")],
+            externalAsks: fiveActions + [action("Action 6"), action("Action 7"), action("Action 8"), action("Action 9")],
             showsLabels: false
         )
         #expect(asksOnly.visiblePresets.isEmpty)
-        #expect(asksOnly.visibleExternalAsks.count == 6)
+        #expect(asksOnly.visibleExternalAsks.count == 8)
         #expect(!asksOnly.showsDivider)
     }
 

--- a/Tests/SpotAskTests/Selection/SelectionActionBarLayoutTests.swift
+++ b/Tests/SpotAskTests/Selection/SelectionActionBarLayoutTests.swift
@@ -4,105 +4,122 @@ import Testing
 
 @Suite("Selection action bar layout")
 struct SelectionActionBarLayoutTests {
-    @Test("Presets only omit the External Ask separator")
-    func presetsOnlyOmitSeparator() {
+    @Test("Presets only omit the External Ask divider")
+    func presetsOnlyOmitDivider() {
         let layout = SelectionActionBarLayout.make(
             presets: [preset("Translate"), preset("Explain")],
-            quickActions: [],
+            externalAsks: [],
             showsLabels: false
         )
         #expect(layout.visiblePresets.count == 2)
-        #expect(layout.visibleQuickActions.isEmpty)
-        #expect(!layout.showsSeparator)
-        #expect(!layout.showsMore)
-        #expect(layout.size.width == 8 + 28 + 2 + 28)
-        #expect(layout.size.height == 36)
+        #expect(layout.visibleExternalAsks.isEmpty)
+        #expect(!layout.showsDivider)
+        #expect(layout.size.width == 66.0)
+        #expect(layout.size.height == 36.0)
     }
 
-    @Test("External Ask actions sit behind a 13pt separator")
-    func compactExternalAskUsesSeparator() {
+    @Test("External Asks sit behind a 9pt divider (1pt line + 4pt margins)")
+    func compactExternalAskUsesDivider() {
         let layout = SelectionActionBarLayout.make(
             presets: [preset("Translate"), preset("Explain")],
-            quickActions: [action("ChatGPT"), action("Grok"), action("Terminal")],
+            externalAsks: [action("ChatGPT"), action("Grok"), action("Terminal")],
             showsLabels: false
         )
-        #expect(layout.showsSeparator)
-        #expect(!layout.showsMore)
-        #expect(layout.visibleQuickActions.count == 3)
-        #expect(layout.size.width == 8 + 58 + 13 + 88)
+        #expect(layout.showsDivider)
+        #expect(layout.visiblePresets.count == 2)
+        #expect(layout.visibleExternalAsks.count == 3)
+        // insets (8) + presets (28*2 + 2 = 58) + divider (9) + external asks (28*3 + 4 = 88) = 163
+        #expect(layout.size.width == 163.0)
+        #expect(layout.size.width <= 400)
     }
 
-    @Test("A fifth External Ask action folds into More")
-    func fifthQuickActionFoldsIntoMore() {
+    @Test("Caps at 4 presets and 3 External Asks")
+    func capsAtFourPresetsAndThreeExternalAsks() {
+        let presets = (1...6).map { preset("Preset \($0)") }
         let actions = (1...5).map { action("Action \($0)") }
         let layout = SelectionActionBarLayout.make(
-            presets: [preset("Translate")],
-            quickActions: actions,
+            presets: presets,
+            externalAsks: actions,
             showsLabels: false
         )
-        #expect(layout.visibleQuickActions.map(\.name) == ["Action 1", "Action 2", "Action 3", "Action 4"])
-        #expect(layout.overflowQuickActions.map(\.name) == ["Action 5"])
-        #expect(layout.showsMore)
-        #expect(layout.showsSeparator)
+        #expect(layout.visiblePresets.count == 4)
+        #expect(layout.visibleExternalAsks.count == 3)
+        #expect(layout.showsDivider)
     }
 
-    @Test("Labeled mode stays at or under 480pt by folding External Ask first")
-    func labeledModeFoldsExternalAskToFit() {
+    @Test("Divider is omitted when presets are empty")
+    func emptyPresetsOmitsDivider() {
+        let layout = SelectionActionBarLayout.make(
+            presets: [],
+            externalAsks: [action("ChatGPT")],
+            showsLabels: false
+        )
+        #expect(!layout.showsDivider)
+        #expect(layout.visiblePresets.isEmpty)
+        #expect(layout.visibleExternalAsks.count == 1)
+    }
+
+    @Test("Labeled mode caps total width at 400pt by truncating External Ask")
+    func labeledModeCapsWidthAt400ptByTruncating() {
         let presets = [
-            preset("Translate Selected Text Now"),
-            preset("Explain Selected Text Now"),
-            preset("Summarize Selected Text Now"),
-            preset("Polish Selected Text Now")
+            preset("Translate"),
+            preset("Explain")
         ]
         let actions = [
-            action("Ask ChatGPT About This Selection"),
-            action("Ask Grok About This Selection"),
-            action("Open Custom App With Selection"),
-            action("Run Terminal Command With Selection")
+            action("Ask ChatGPT A Very Long Question That Exceeds Normal Length"),
+            action("Ask Grok A Very Long Question That Exceeds Normal Length"),
+            action("Run Terminal Command A Very Long Question That Exceeds Normal Length")
         ]
         let layout = SelectionActionBarLayout.make(
             presets: presets,
-            quickActions: actions,
+            externalAsks: actions,
             showsLabels: true
         )
-        #expect(layout.size.width <= 480)
-        #expect(layout.visiblePresets.count == 4)
-        #expect(layout.visibleQuickActions.count < 4 || layout.overflowQuickActions.isEmpty)
-        #expect(layout.overflowPresets.isEmpty)
-        #expect(layout.showsMore)
-    }
-
-    @Test("Extreme labeled overflow folds presets only after External Ask is gone")
-    func labeledModeFoldsPresetsAfterExternalAsk() {
-        let presets = (1...4).map { preset(String(repeating: "PresetTitle", count: $0 + 3)) }
-        let actions = (1...4).map { action(String(repeating: "ExternalAskTitle", count: $0 + 3)) }
-        let layout = SelectionActionBarLayout.make(
-            presets: presets,
-            quickActions: actions,
-            showsLabels: true
-        )
-        #expect(layout.size.width <= 480)
-        if !layout.visibleQuickActions.isEmpty {
-            #expect(layout.overflowPresets.isEmpty)
+        #expect(layout.size.width <= 400)
+        #expect(layout.visiblePresets.count == 2)
+        // Should truncate titles to fit within 400pt
+        for width in layout.visibleExternalAskWidths {
+            #expect(width >= 48)
         }
     }
 
-    @Test("Tooltips include type and shortcut for External Ask")
-    func tooltipIncludesKindAndShortcut() {
+    @Test("Extreme labeled overflow drops trailing External Ask buttons while keeping presets")
+    func labeledModeDropsTrailingExternalAsksWhenMin48Exceeds() {
+        let presets = [
+            preset("A Very Long Prompt Preset Title That Consumes A Lot Of Space"),
+            preset("Another Extremely Long Prompt Preset Title In The Selection Bar"),
+            preset("Third Long Prompt Preset Title Taking Remaining Width In Bar")
+        ]
+        let actions = [
+            action("Action 1"),
+            action("Action 2"),
+            action("Action 3")
+        ]
+        let layout = SelectionActionBarLayout.make(
+            presets: presets,
+            externalAsks: actions,
+            showsLabels: true
+        )
+        #expect(layout.size.width <= 400)
+        #expect(layout.visiblePresets.count == 3)
+        // External asks should be dropped to 0 or 1 to fit under 400
+        #expect(layout.visibleExternalAsks.count < 3)
+    }
+
+    @Test("Tooltips append tab-separated shortcut when assigned")
+    func tooltipAppendsTabSeparatedShortcut() {
         let shortcut = InAppShortcut.commandShift("1")
         #expect(
             SelectionActionBarLayout.tooltip(
                 name: "Ask ChatGPT",
-                kind: "网页提问",
                 shortcut: shortcut
-            ) == "Ask ChatGPT — 网页提问（⌘⇧1）"
+            ) == "Ask ChatGPT\t⌘⇧1"
         )
         #expect(
             SelectionActionBarLayout.tooltip(
                 name: "Translate",
-                kind: nil,
-                shortcut: shortcut
-            ) == "Translate（⌘⇧1）"
+                shortcut: nil
+            ) == "Translate"
         )
     }
 

--- a/Tests/SpotAskTests/Selection/SelectionActionBarLayoutTests.swift
+++ b/Tests/SpotAskTests/Selection/SelectionActionBarLayoutTests.swift
@@ -99,6 +99,7 @@ struct SelectionActionBarLayoutTests {
         for width in layout.visibleExternalAskWidths {
             #expect(width >= 48)
         }
+        expectButtonsStayInsidePanel(layout)
     }
 
     @Test("Extreme labeled overflow drops trailing External Ask buttons while keeping presets")
@@ -122,6 +123,7 @@ struct SelectionActionBarLayoutTests {
         #expect(layout.visiblePresets.count == 3)
         // External asks should be dropped to 0 or 1 to fit under 400
         #expect(layout.visibleExternalAsks.count < 3)
+        expectButtonsStayInsidePanel(layout)
     }
 
     @Test("Tooltips append tab-separated shortcut when assigned")
@@ -141,11 +143,81 @@ struct SelectionActionBarLayoutTests {
         )
     }
 
+    @Test("Labeled long prompts stay inside the 400pt panel and remain clickable")
+    func labeledLongPromptsStayInsidePanel() {
+        let presets = [
+            preset("A Very Long Prompt Preset Title That Consumes A Lot Of Space"),
+            preset("Another Extremely Long Prompt Preset Title In The Selection Bar"),
+            preset("Third Long Prompt Preset Title Taking Remaining Width In Bar")
+        ]
+        let layout = SelectionActionBarLayout.make(
+            presets: presets,
+            externalAsks: [],
+            showsLabels: true
+        )
+        #expect(layout.visiblePresets.count == 3)
+        #expect(layout.visibleExternalAsks.isEmpty)
+        expectButtonsStayInsidePanel(layout)
+        let frames = layout.placedItems.map(\.frame)
+        #expect(frames.count == 3)
+        #expect(frames.allSatisfy { $0.maxX <= SelectionActionBarLayout.maxTotalWidth })
+        #expect(frames.allSatisfy { $0.width > 0 })
+    }
+
+    @Test("Eight labeled prompts stay inside 400pt")
+    func eightLabeledPromptsStayInsidePanel() {
+        let presets = (1...8).map { preset("Labeled Prompt Title Number \($0) With Extra Words") }
+        let layout = SelectionActionBarLayout.make(
+            presets: presets,
+            externalAsks: [],
+            showsLabels: true
+        )
+        #expect(layout.visiblePresets.count == 8)
+        expectButtonsStayInsidePanel(layout)
+    }
+
+    @Test("Eight labeled mixed actions keep prompts and fit the panel")
+    func eightLabeledMixedActionsStayInsidePanel() {
+        let presets = (1...5).map { preset("Prompt \($0) With A Long Visible Title") }
+        let actions = (1...5).map { action("External Ask Target \($0) With A Long Name") }
+        let layout = SelectionActionBarLayout.make(
+            presets: presets,
+            externalAsks: actions,
+            showsLabels: true
+        )
+        #expect(layout.visiblePresets.count == 5)
+        #expect(layout.visibleExternalAsks.count <= 3)
+        expectButtonsStayInsidePanel(layout)
+    }
+
     private func preset(_ title: String) -> PromptPreset {
         PromptPreset(title: title, instruction: "Do it")
     }
 
     private func action(_ name: String) -> QuickAction {
         QuickAction(name: name, kind: .web(urlTemplate: "https://example.com/?q={query}"))
+    }
+
+    private func expectButtonsStayInsidePanel(_ layout: SelectionActionBarLayout) {
+        #expect(layout.size.width <= SelectionActionBarLayout.maxTotalWidth)
+        #expect(layout.visiblePresets.count == layout.visiblePresetWidths.count)
+        #expect(layout.visibleExternalAsks.count == layout.visibleExternalAskWidths.count)
+        let panel = NSRect(origin: .zero, size: layout.size)
+        let inset = SelectionActionBarLayout.contentInset
+        for item in layout.placedItems {
+            let frame = item.frame
+            #expect(frame.width > 0)
+            #expect(frame.minX >= 0)
+            #expect(frame.maxX <= panel.maxX + 0.001)
+            #expect(frame.minY >= 0)
+            #expect(frame.maxY <= panel.maxY + 0.001)
+            switch item {
+            case .preset, .externalAsk:
+                #expect(frame.minX >= inset - 0.001)
+                #expect(frame.maxX <= panel.maxX - inset + 0.001)
+            case .divider:
+                break
+            }
+        }
     }
 }

--- a/Tests/SpotAskTests/Selection/SelectionAssistantCoordinatorTests.swift
+++ b/Tests/SpotAskTests/Selection/SelectionAssistantCoordinatorTests.swift
@@ -393,6 +393,93 @@ struct SelectionAssistantCoordinatorTests {
         #expect(overlay.messages == [.temporaryFailure])
     }
 
+    @Test("An empty follow-up read hides the bar and blocks stale External Ask")
+    func emptyFollowUpReadInvalidatesPresentedActions() async {
+        let settings = makeSettings()
+        let overlay = SelectionOverlayStub()
+        let executor = RecordingQuickActionExecutor()
+        let reader = SelectionReaderStub(snapshot: sampleSnapshot)
+        let coordinator = makeCoordinator(
+            settings: settings,
+            reader: reader,
+            overlay: overlay,
+            executor: executor
+        )
+
+        coordinator.trigger()
+        for _ in 0 ..< 20 where overlay.quickActions.isEmpty {
+            await Task.yield()
+        }
+        #expect(overlay.hasActionHandler)
+
+        reader.snapshot = makeSnapshot(text: " \n ")
+        coordinator.trigger()
+        for _ in 0 ..< 200 where overlay.hasActionHandler {
+            await Task.yield()
+        }
+
+        #expect(!overlay.hasActionHandler)
+        overlay.chooseFirstQuickAction()
+        #expect(executor.performed.isEmpty)
+    }
+
+    @Test("A failed follow-up read hides the bar and drops the snapshot")
+    func failedFollowUpReadInvalidatesPresentedActions() async {
+        let settings = makeSettings()
+        let overlay = SelectionOverlayStub()
+        let executor = RecordingQuickActionExecutor()
+        let reader = SelectionReaderStub(snapshot: sampleSnapshot)
+        let coordinator = makeCoordinator(
+            settings: settings,
+            reader: reader,
+            overlay: overlay,
+            executor: executor
+        )
+
+        coordinator.trigger()
+        for _ in 0 ..< 20 where overlay.quickActions.isEmpty {
+            await Task.yield()
+        }
+        #expect(overlay.hasActionHandler)
+
+        reader.error = SelectionReadingError.noSelection
+        coordinator.trigger()
+        for _ in 0 ..< 200 where overlay.messages.isEmpty {
+            await Task.yield()
+        }
+
+        #expect(!overlay.hasActionHandler)
+        #expect(overlay.messages == [.noSelection])
+        overlay.chooseFirstQuickAction()
+        #expect(executor.performed.isEmpty)
+    }
+
+    @Test("Disabling the assistant hides an existing action bar")
+    func disablingAssistantHidesActionBar() async {
+        let settings = makeSettings()
+        let overlay = SelectionOverlayStub()
+        let executor = RecordingQuickActionExecutor()
+        let coordinator = makeCoordinator(
+            settings: settings,
+            reader: SelectionReaderStub(snapshot: sampleSnapshot),
+            overlay: overlay,
+            executor: executor
+        )
+
+        coordinator.trigger()
+        for _ in 0 ..< 20 where overlay.quickActions.isEmpty {
+            await Task.yield()
+        }
+        #expect(overlay.hasActionHandler)
+
+        settings.selectionAssistantEnabled = false
+        coordinator.handleSettingsChanged()
+
+        #expect(!overlay.hasActionHandler)
+        overlay.chooseFirstQuickAction()
+        #expect(executor.performed.isEmpty)
+    }
+
     private func makeSettings() -> AppSettings {
         let suiteName = "SelectionAssistantCoordinatorTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -471,7 +558,8 @@ private final class MemorySelectionGrantIdentityStore: AccessibilityGrantIdentit
 }
 
 private final class SelectionReaderStub: SelectedTextReading, @unchecked Sendable {
-    let snapshot: SelectedTextSnapshot
+    var snapshot: SelectedTextSnapshot
+    var error: (any Error)?
     private(set) var promptRequests: [Bool] = []
 
     init(snapshot: SelectedTextSnapshot = .init(
@@ -485,6 +573,7 @@ private final class SelectionReaderStub: SelectedTextReading, @unchecked Sendabl
 
     func readSelection(promptForPermission: Bool) async throws -> SelectedTextSnapshot {
         promptRequests.append(promptForPermission)
+        if let error { throw error }
         return snapshot
     }
 }
@@ -549,7 +638,13 @@ private final class SelectionOverlayStub: SelectionOverlayControlling {
     }
     func showMessage(_ message: SelectionFeedback) { messages.append(message) }
     func showPermissionDenied(openSettings: @escaping () -> Void) { permissionDeniedCount += 1 }
-    func hide() { hideCount += 1 }
+    func hide() {
+        hideCount += 1
+        actionHandler = nil
+        quickActionHandler = nil
+        shownPresets = []
+        quickActions = []
+    }
 
     func chooseFirstAction() {
         guard let preset = shownPresets.first else { return }

--- a/Tests/SpotAskTests/Selection/SelectionAssistantCoordinatorTests.swift
+++ b/Tests/SpotAskTests/Selection/SelectionAssistantCoordinatorTests.swift
@@ -238,6 +238,102 @@ struct SelectionAssistantCoordinatorTests {
         #expect(overlay.hasActionHandler)
     }
 
+    @Test("Action bar receives enabled External Ask actions by default")
+    func actionBarIncludesEnabledQuickActionsByDefault() async {
+        let settings = makeSettings()
+        let overlay = SelectionOverlayStub()
+        let coordinator = makeCoordinator(settings: settings, reader: SelectionReaderStub(snapshot: sampleSnapshot), overlay: overlay)
+
+        coordinator.trigger()
+        for _ in 0 ..< 20 where overlay.quickActions.isEmpty {
+            await Task.yield()
+        }
+
+        #expect(overlay.quickActions.map(\.id) == settings.enabledQuickActions.map(\.id))
+        #expect(!overlay.quickActions.isEmpty)
+    }
+
+    @Test("Hiding External Ask in the action bar restores preset-only actions")
+    func hidingExternalAskOmitsQuickActions() async {
+        let settings = makeSettings()
+        settings.selectionActionBarShowsExternalAsk = false
+        let overlay = SelectionOverlayStub()
+        let coordinator = makeCoordinator(settings: settings, reader: SelectionReaderStub(snapshot: sampleSnapshot), overlay: overlay)
+
+        coordinator.trigger()
+        for _ in 0 ..< 20 where !overlay.hasActionHandler {
+            await Task.yield()
+        }
+
+        #expect(overlay.quickActions.isEmpty)
+        #expect(overlay.hasActionHandler)
+    }
+
+    @Test("Disabling External Ask omits quick actions from the action bar")
+    func disablingExternalAskOmitsQuickActions() async {
+        let settings = makeSettings()
+        settings.externalAskEnabled = false
+        let overlay = SelectionOverlayStub()
+        let coordinator = makeCoordinator(settings: settings, reader: SelectionReaderStub(snapshot: sampleSnapshot), overlay: overlay)
+
+        coordinator.trigger()
+        for _ in 0 ..< 20 where !overlay.hasActionHandler {
+            await Task.yield()
+        }
+
+        #expect(overlay.quickActions.isEmpty)
+    }
+
+    @Test("Choosing an External Ask action injects selected text into the executor")
+    func choosingQuickActionExecutesWithSelectedText() async {
+        let settings = makeSettings()
+        let overlay = SelectionOverlayStub()
+        let executor = RecordingQuickActionExecutor()
+        let coordinator = makeCoordinator(
+            settings: settings,
+            reader: SelectionReaderStub(snapshot: sampleSnapshot),
+            overlay: overlay,
+            executor: executor
+        )
+
+        coordinator.trigger()
+        for _ in 0 ..< 20 where overlay.quickActions.isEmpty {
+            await Task.yield()
+        }
+        overlay.chooseFirstQuickAction()
+
+        #expect(overlay.hideCount == 1)
+        #expect(executor.performed.count == 1)
+        #expect(overlay.messages.isEmpty)
+        guard case let .url(url) = executor.performed.first else {
+            Issue.record("expected a URL quick action")
+            return
+        }
+        #expect(url.absoluteString.contains("Selected%20text") || url.absoluteString.contains("Selected text"))
+    }
+
+    @Test("A failed External Ask action shows the temporary failure message")
+    func failedQuickActionShowsTemporaryFailure() async {
+        let settings = makeSettings()
+        let overlay = SelectionOverlayStub()
+        let executor = RecordingQuickActionExecutor(result: false)
+        let coordinator = makeCoordinator(
+            settings: settings,
+            reader: SelectionReaderStub(snapshot: sampleSnapshot),
+            overlay: overlay,
+            executor: executor
+        )
+
+        coordinator.trigger()
+        for _ in 0 ..< 20 where overlay.quickActions.isEmpty {
+            await Task.yield()
+        }
+        overlay.chooseFirstQuickAction()
+
+        #expect(overlay.hideCount == 1)
+        #expect(overlay.messages == [.temporaryFailure])
+    }
+
     private func makeSettings() -> AppSettings {
         let suiteName = "SelectionAssistantCoordinatorTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -251,7 +347,8 @@ struct SelectionAssistantCoordinatorTests {
     private func makeCoordinator(
         settings: AppSettings,
         reader: any SelectedTextReading,
-        overlay: SelectionOverlayStub = SelectionOverlayStub()
+        overlay: SelectionOverlayStub = SelectionOverlayStub(),
+        executor: any QuickActionExecuting = DefaultQuickActionExecutor()
     ) -> SelectionAssistantCoordinator {
         SelectionAssistantCoordinator(
             settings: settings,
@@ -262,7 +359,8 @@ struct SelectionAssistantCoordinatorTests {
             ),
             settingsOpener: SelectionSettingsOpenerStub(),
             commandCenter: SpotAskCommandCenter(),
-            overlay: overlay
+            overlay: overlay,
+            executor: executor
         )
     }
 
@@ -369,27 +467,56 @@ private struct ForegroundSelectionApplicationStub: ForegroundSelectionApplicatio
 private final class SelectionOverlayStub: SelectionOverlayControlling {
     private(set) var permissionDeniedCount = 0
     private(set) var hideCount = 0
+    private(set) var messages: [SelectionFeedback] = []
+    private(set) var quickActions: [QuickAction] = []
     private var presets: [PromptPreset] = []
     private var actionHandler: ((PromptPreset) -> Void)?
+    private var quickActionHandler: ((QuickAction) -> Void)?
 
     var hasActionHandler: Bool { actionHandler != nil }
 
     func showActions(
         snapshot: SelectedTextSnapshot,
         presets: [PromptPreset],
+        quickActions: [QuickAction],
         showsLabels: Bool,
-        onSelect: @escaping (PromptPreset) -> Void
+        shortcutForPreset: @escaping (PromptPreset) -> InAppShortcut?,
+        shortcutForAction: @escaping (QuickAction) -> InAppShortcut?,
+        onSelect: @escaping (PromptPreset) -> Void,
+        onSelectQuickAction: @escaping (QuickAction) -> Void
     ) {
         self.presets = presets
+        self.quickActions = quickActions
         actionHandler = onSelect
+        quickActionHandler = onSelectQuickAction
     }
-    func showMessage(_ message: SelectionFeedback) {}
+    func showMessage(_ message: SelectionFeedback) { messages.append(message) }
     func showPermissionDenied(openSettings: @escaping () -> Void) { permissionDeniedCount += 1 }
     func hide() { hideCount += 1 }
 
     func chooseFirstAction() {
         guard let preset = presets.first else { return }
         actionHandler?(preset)
+    }
+
+    func chooseFirstQuickAction() {
+        guard let action = quickActions.first else { return }
+        quickActionHandler?(action)
+    }
+}
+
+@MainActor
+private final class RecordingQuickActionExecutor: QuickActionExecuting, @unchecked Sendable {
+    var result: Bool
+    private(set) var performed: [ResolvedQuickAction] = []
+
+    init(result: Bool = true) {
+        self.result = result
+    }
+
+    func perform(_ resolved: ResolvedQuickAction) -> Bool {
+        performed.append(resolved)
+        return result
     }
 }
 

--- a/Tests/SpotAskTests/Selection/SelectionAssistantCoordinatorTests.swift
+++ b/Tests/SpotAskTests/Selection/SelectionAssistantCoordinatorTests.swift
@@ -238,7 +238,7 @@ struct SelectionAssistantCoordinatorTests {
         #expect(overlay.hasActionHandler)
     }
 
-    @Test("Action bar receives enabled External Ask actions by default")
+    @Test("Action bar receives enabled External Ask actions by default (up to 3)")
     func actionBarIncludesEnabledQuickActionsByDefault() async {
         let settings = makeSettings()
         let overlay = SelectionOverlayStub()
@@ -249,7 +249,7 @@ struct SelectionAssistantCoordinatorTests {
             await Task.yield()
         }
 
-        #expect(overlay.quickActions.map(\.id) == settings.enabledQuickActions.map(\.id))
+        #expect(overlay.quickActions.map(\.id) == Array(settings.enabledQuickActions.prefix(3)).map(\.id))
         #expect(!overlay.quickActions.isEmpty)
     }
 
@@ -478,17 +478,15 @@ private final class SelectionOverlayStub: SelectionOverlayControlling {
     func showActions(
         snapshot: SelectedTextSnapshot,
         presets: [PromptPreset],
-        quickActions: [QuickAction],
+        externalAsks: [QuickAction],
         showsLabels: Bool,
-        shortcutForPreset: @escaping (PromptPreset) -> InAppShortcut?,
-        shortcutForAction: @escaping (QuickAction) -> InAppShortcut?,
-        onSelect: @escaping (PromptPreset) -> Void,
-        onSelectQuickAction: @escaping (QuickAction) -> Void
+        onSelectPreset: @escaping (PromptPreset) -> Void,
+        onSelectExternalAsk: @escaping (QuickAction) -> Void
     ) {
         self.presets = presets
-        self.quickActions = quickActions
-        actionHandler = onSelect
-        quickActionHandler = onSelectQuickAction
+        self.quickActions = externalAsks
+        actionHandler = onSelectPreset
+        quickActionHandler = onSelectExternalAsk
     }
     func showMessage(_ message: SelectionFeedback) { messages.append(message) }
     func showPermissionDenied(openSettings: @escaping () -> Void) { permissionDeniedCount += 1 }

--- a/Tests/SpotAskTests/Selection/SelectionAssistantCoordinatorTests.swift
+++ b/Tests/SpotAskTests/Selection/SelectionAssistantCoordinatorTests.swift
@@ -238,7 +238,7 @@ struct SelectionAssistantCoordinatorTests {
         #expect(overlay.hasActionHandler)
     }
 
-    @Test("Action bar receives enabled External Ask actions by default (up to 3)")
+    @Test("Action bar receives enabled External Ask actions by default")
     func actionBarIncludesEnabledQuickActionsByDefault() async {
         let settings = makeSettings()
         let overlay = SelectionOverlayStub()
@@ -249,8 +249,9 @@ struct SelectionAssistantCoordinatorTests {
             await Task.yield()
         }
 
-        #expect(overlay.quickActions.map(\.id) == Array(settings.enabledQuickActions.prefix(3)).map(\.id))
+        #expect(overlay.quickActions.map(\.id) == settings.enabledQuickActions.map(\.id))
         #expect(!overlay.quickActions.isEmpty)
+        #expect(!overlay.shownPresets.isEmpty)
     }
 
     @Test("Hiding External Ask in the action bar restores preset-only actions")
@@ -267,6 +268,62 @@ struct SelectionAssistantCoordinatorTests {
 
         #expect(overlay.quickActions.isEmpty)
         #expect(overlay.hasActionHandler)
+    }
+
+    @Test("Hiding prompts in the action bar restores External Ask-only actions")
+    func hidingPromptsOmitsPresetActions() async {
+        let settings = makeSettings()
+        settings.selectionActionBarShowsPrompts = false
+        let overlay = SelectionOverlayStub()
+        let coordinator = makeCoordinator(settings: settings, reader: SelectionReaderStub(snapshot: sampleSnapshot), overlay: overlay)
+
+        coordinator.trigger()
+        for _ in 0 ..< 20 where !overlay.hasActionHandler {
+            await Task.yield()
+        }
+
+        #expect(overlay.shownPresets.isEmpty)
+        #expect(!overlay.quickActions.isEmpty)
+        #expect(overlay.hasActionHandler)
+    }
+
+    @Test("Hiding prompts and External Ask does not show the action bar")
+    func hidingBothGroupsSkipsTheActionBar() async {
+        let settings = makeSettings()
+        settings.selectionActionBarShowsPrompts = false
+        settings.selectionActionBarShowsExternalAsk = false
+        let reader = SelectionReaderStub(snapshot: sampleSnapshot)
+        let overlay = SelectionOverlayStub()
+        let coordinator = makeCoordinator(settings: settings, reader: reader, overlay: overlay)
+
+        coordinator.trigger()
+        for _ in 0 ..< 20 where reader.promptRequests.isEmpty {
+            await Task.yield()
+        }
+
+        #expect(reader.promptRequests == [false])
+        #expect(!overlay.hasActionHandler)
+        #expect(overlay.shownPresets.isEmpty)
+        #expect(overlay.quickActions.isEmpty)
+    }
+
+    @Test("Action bar keeps prompts and folds trailing External Ask at a combined cap of 6")
+    func actionBarCapsCombinedActionsAtSixPreferringPresets() async {
+        let settings = makeSettings()
+        #expect(settings.saveCustomPromptPreset(PromptPreset(title: "Custom A", instruction: "Do A")))
+        #expect(settings.saveCustomPromptPreset(PromptPreset(title: "Custom B", instruction: "Do B")))
+        settings.setQuickActionEnabled(id: QuickAction.BuiltInID.grok, isEnabled: true)
+        let overlay = SelectionOverlayStub()
+        let coordinator = makeCoordinator(settings: settings, reader: SelectionReaderStub(snapshot: sampleSnapshot), overlay: overlay)
+
+        coordinator.trigger()
+        for _ in 0 ..< 20 where overlay.shownPresets.count < 6 {
+            await Task.yield()
+        }
+
+        #expect(overlay.shownPresets.count == 6)
+        #expect(overlay.quickActions.isEmpty)
+        #expect(overlay.shownPresets.map(\.id) == Array(settings.enabledPromptPresets.prefix(6)).map(\.id))
     }
 
     @Test("Disabling External Ask omits quick actions from the action bar")
@@ -469,7 +526,7 @@ private final class SelectionOverlayStub: SelectionOverlayControlling {
     private(set) var hideCount = 0
     private(set) var messages: [SelectionFeedback] = []
     private(set) var quickActions: [QuickAction] = []
-    private var presets: [PromptPreset] = []
+    private(set) var shownPresets: [PromptPreset] = []
     private var actionHandler: ((PromptPreset) -> Void)?
     private var quickActionHandler: ((QuickAction) -> Void)?
 
@@ -483,7 +540,7 @@ private final class SelectionOverlayStub: SelectionOverlayControlling {
         onSelectPreset: @escaping (PromptPreset) -> Void,
         onSelectExternalAsk: @escaping (QuickAction) -> Void
     ) {
-        self.presets = presets
+        shownPresets = presets
         self.quickActions = externalAsks
         actionHandler = onSelectPreset
         quickActionHandler = onSelectExternalAsk
@@ -493,7 +550,7 @@ private final class SelectionOverlayStub: SelectionOverlayControlling {
     func hide() { hideCount += 1 }
 
     func chooseFirstAction() {
-        guard let preset = presets.first else { return }
+        guard let preset = shownPresets.first else { return }
         actionHandler?(preset)
     }
 

--- a/Tests/SpotAskTests/Selection/SelectionAssistantCoordinatorTests.swift
+++ b/Tests/SpotAskTests/Selection/SelectionAssistantCoordinatorTests.swift
@@ -307,23 +307,25 @@ struct SelectionAssistantCoordinatorTests {
         #expect(overlay.quickActions.isEmpty)
     }
 
-    @Test("Action bar keeps prompts and folds trailing External Ask at a combined cap of 6")
-    func actionBarCapsCombinedActionsAtSixPreferringPresets() async {
+    @Test("Action bar keeps prompts and folds trailing External Ask at a combined cap of 8")
+    func actionBarCapsCombinedActionsAtEightPreferringPresets() async {
         let settings = makeSettings()
         #expect(settings.saveCustomPromptPreset(PromptPreset(title: "Custom A", instruction: "Do A")))
         #expect(settings.saveCustomPromptPreset(PromptPreset(title: "Custom B", instruction: "Do B")))
+        #expect(settings.saveCustomPromptPreset(PromptPreset(title: "Custom C", instruction: "Do C")))
+        #expect(settings.saveCustomPromptPreset(PromptPreset(title: "Custom D", instruction: "Do D")))
         settings.setQuickActionEnabled(id: QuickAction.BuiltInID.grok, isEnabled: true)
         let overlay = SelectionOverlayStub()
         let coordinator = makeCoordinator(settings: settings, reader: SelectionReaderStub(snapshot: sampleSnapshot), overlay: overlay)
 
         coordinator.trigger()
-        for _ in 0 ..< 20 where overlay.shownPresets.count < 6 {
+        for _ in 0 ..< 20 where overlay.shownPresets.count < 8 {
             await Task.yield()
         }
 
-        #expect(overlay.shownPresets.count == 6)
+        #expect(overlay.shownPresets.count == 8)
         #expect(overlay.quickActions.isEmpty)
-        #expect(overlay.shownPresets.map(\.id) == Array(settings.enabledPromptPresets.prefix(6)).map(\.id))
+        #expect(overlay.shownPresets.map(\.id) == Array(settings.enabledPromptPresets.prefix(8)).map(\.id))
     }
 
     @Test("Disabling External Ask omits quick actions from the action bar")

--- a/Tests/SpotAskTests/SettingsLayoutTests.swift
+++ b/Tests/SpotAskTests/SettingsLayoutTests.swift
@@ -64,7 +64,7 @@ struct SettingsLayoutTests {
     }
 
     @Test func otherSettingsPagesKeepTheirExpectedScrollBehavior() throws {
-        let scrollingSections: Set<SettingsSection> = [.provider, .prompts, .externalAsk, .shortcuts, .general]
+        let scrollingSections: Set<SettingsSection> = [.provider, .prompts, .externalAsk, .selectionAssistant, .shortcuts, .general]
 
         for section in SettingsSection.allCases {
             let fixture = makeWindow(section: section)


### PR DESCRIPTION
Closes DEV-51
Closes DEV-52
Closes #3

v1.1 increment for the selection action bar:

- Independent `selectionActionBarShowsPrompts` toggle (default on). Both group switches off skips the bar.
- Combined visible cap of 8. Prompts keep priority; trailing External Ask items fold first. 400pt width overflow still drops External Ask first. If remaining prompt titles still overflow, they truncate so every retained button stays inside the panel and clickable. Full names stay on the tooltip.
- Empty or failed selection reads, and turning the assistant off, dismiss the bar and drop the captured snapshot.
- Settings hint when enabled prompt count + enabled External Ask count is greater than 4.
- Icon path unchanged: `brandIconSlug` → stored `symbolName` (editor choice) → `globe`.

This branch includes merged `main` (`6784d4c`, PR #4) so the same HEAD also registers `spotask://` (`open`, `ask?q=`, `toggle`, `settings`).