### PR TITLE
Closes DEV-54: chore(release): update version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - 2026-09-08
+## [0.2.1] - 2026-09-08
 
 ### Added
 
@@ -126,8 +126,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Provider cards can be expanded and collapsed reliably.
 - Thinking expansion behavior: when enabled, thinking stays expanded during reasoning and collapses for the final answer; when disabled, it stays collapsed.
 
-[Unreleased]: https://github.com/shiquda/SpotAsk/compare/v0.3.0...HEAD
-[0.3.0]: https://github.com/shiquda/SpotAsk/compare/v0.2.0...v0.3.0
+[Unreleased]: https://github.com/shiquda/SpotAsk/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/shiquda/SpotAsk/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/shiquda/SpotAsk/compare/v0.1.6...v0.2.0
 [0.1.6]: https://github.com/shiquda/SpotAsk/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/shiquda/SpotAsk/compare/v0.1.4...v0.1.5

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -22,7 +22,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>20</string>
 	<key>CFBundleURLTypes</key>

--- a/SpotAsk.xcodeproj/project.pbxproj
+++ b/SpotAsk.xcodeproj/project.pbxproj
@@ -529,7 +529,7 @@
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotask.app.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -551,7 +551,7 @@
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotask.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;


### PR DESCRIPTION
Closes DEV-54.

### Release v0.2.1

Update version to 0.2.1 (build 20):
- **URL Scheme**: full URL scheme support (`spotask://open`, `spotask://ask?q=`, `spotask://toggle`, `spotask://settings`).
- **Selection Action Bar**: integrate enabled External Ask actions into the floating action bar with custom toggles and a combined visible cap of 8.
- **Homebrew Cask**: add official Cask distribution support (`brew install --cask spotask`).
- **Input & Window Fixes**: properly clear input after External Ask, preserve composed/multiline input, and keep unpinned window behind during Space switching.
- **Defaults**: disable Grok quick action by default on fresh installations.