### PR TITLE
chore: update Homebrew cask for v0.2.2

### DIFF
--- a/Casks/spotask.rb
+++ b/Casks/spotask.rb
@@ -1,13 +1,13 @@
 cask "spotask" do
-  version "0.2.1"
+  version "0.2.2"
 
   on_arm do
-    sha256 "25c632d5f0d47c90a84499ece9b8403347a07df90269226c0315e5a1abf8e006"
+    sha256 "7694809d875e2ccd7987f3b62de4ba3dd463b604d97941e92774b580f1ad2987"
 
     url "https://github.com/shiquda/SpotAsk/releases/download/v#{version}/SpotAsk-#{version}-arm64.dmg"
   end
   on_intel do
-    sha256 "554957d32b53a45da2d5a57de5f0b55833cf9a998c84e731f065b4417c771759"
+    sha256 "09dea9072b4f8500560783ae916c7076fd346f3ce27c0d286778235e1bc58dd9"
 
     url "https://github.com/shiquda/SpotAsk/releases/download/v#{version}/SpotAsk-#{version}-x86_64.dmg"
   end


### PR DESCRIPTION
The v0.2.2 GitHub Release published successfully, but the Release workflow could not push `Casks/spotask.rb` because `main` requires the arm64/x86_64 CI checks.

This PR updates the cask to the published DMGs:

- arm64 `7694809d875e2ccd7987f3b62de4ba3dd463b604d97941e92774b580f1ad2987`
- x86_64 `09dea9072b4f8500560783ae916c7076fd346f3ce27c0d286778235e1bc58dd9`

Follow-up to https://github.com/shiquda/SpotAsk/pull/11 and https://github.com/shiquda/SpotAsk/releases/tag/v0.2.2.