### PR TITLE
ui(settings): compact LookAway-style sidebar layout

### DIFF
--- a/Sources/SpotAsk/Resources/de.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/de.lproj/Localizable.strings
@@ -371,6 +371,12 @@
 "settings.upstreamModelID" = "Modell-ID";
 "settings.useForChat" = "Für Chat verwenden";
 "settings.selectionAssistant" = "Auswahlassistent";
+"settings.groupCore" = "Kern";
+"settings.groupAutomation" = "Automatisierung";
+"settings.groupApp" = "App";
+"settings.searchPlaceholder" = "Einstellungen suchen";
+"settings.noSearchResults" = "Keine passenden Einstellungen";
+"settings.clearSearch" = "Suche löschen";
 "settings.selectionAssistantDescription" = "Wähle Text in einer anderen App aus und drücke dann das Auswahlkürzel, um zu übersetzen, zusammenzufassen oder SpotAsk danach zu fragen.";
 "settings.selectionAssistantEnabled" = "Auswahlassistent aktivieren";
 "settings.selectionAssistantToggleShortcut" = "Schnellfragenmodus umschalten";

--- a/Sources/SpotAsk/Resources/en.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/en.lproj/Localizable.strings
@@ -371,6 +371,12 @@
 "settings.upstreamModelID" = "Model ID";
 "settings.useForChat" = "Use for Chat";
 "settings.selectionAssistant" = "Selection Assistant";
+"settings.groupCore" = "Core";
+"settings.groupAutomation" = "Automation";
+"settings.groupApp" = "App";
+"settings.searchPlaceholder" = "Search settings";
+"settings.noSearchResults" = "No matching settings";
+"settings.clearSearch" = "Clear Search";
 "settings.selectionAssistantDescription" = "Select text in another app, then press the selection shortcut to translate, summarize, or ask SpotAsk about it.";
 "settings.selectionAssistantEnabled" = "Enable Selection Assistant";
 "settings.selectionAssistantToggleShortcut" = "Toggle Quick Question Mode";

--- a/Sources/SpotAsk/Resources/es.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/es.lproj/Localizable.strings
@@ -371,6 +371,12 @@
 "settings.upstreamModelID" = "ID del modelo";
 "settings.useForChat" = "Usar en el chat";
 "settings.selectionAssistant" = "Asistente de selección";
+"settings.groupCore" = "Núcleo";
+"settings.groupAutomation" = "Automatización";
+"settings.groupApp" = "App";
+"settings.searchPlaceholder" = "Buscar ajustes";
+"settings.noSearchResults" = "No hay ajustes coincidentes";
+"settings.clearSearch" = "Borrar búsqueda";
 "settings.selectionAssistantDescription" = "Selecciona texto en otra app y pulsa el atajo de selección para traducir, resumir o preguntar a SpotAsk sobre él.";
 "settings.selectionAssistantEnabled" = "Activar asistente de selección";
 "settings.selectionAssistantToggleShortcut" = "Alternar modo de pregunta rápida";

--- a/Sources/SpotAsk/Resources/fr.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/fr.lproj/Localizable.strings
@@ -371,6 +371,12 @@
 "settings.upstreamModelID" = "ID du modèle";
 "settings.useForChat" = "Utiliser pour le chat";
 "settings.selectionAssistant" = "Assistant de sélection";
+"settings.groupCore" = "Fonctions principales";
+"settings.groupAutomation" = "Automatisation";
+"settings.groupApp" = "App";
+"settings.searchPlaceholder" = "Rechercher dans les réglages";
+"settings.noSearchResults" = "Aucun réglage correspondant";
+"settings.clearSearch" = "Effacer la recherche";
 "settings.selectionAssistantDescription" = "Sélectionnez du texte dans une autre app, puis appuyez sur le raccourci de sélection pour traduire, résumer ou demander à SpotAsk.";
 "settings.selectionAssistantEnabled" = "Activer l'assistant de sélection";
 "settings.selectionAssistantToggleShortcut" = "Basculer le mode question rapide";

--- a/Sources/SpotAsk/Resources/ja.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/ja.lproj/Localizable.strings
@@ -371,6 +371,12 @@
 "settings.upstreamModelID" = "モデル ID";
 "settings.useForChat" = "チャットで使用";
 "settings.selectionAssistant" = "選択アシスタント";
+"settings.groupCore" = "コア";
+"settings.groupAutomation" = "自動化";
+"settings.groupApp" = "アプリ";
+"settings.searchPlaceholder" = "設定を検索";
+"settings.noSearchResults" = "一致する設定はありません";
+"settings.clearSearch" = "検索を消去";
 "settings.selectionAssistantDescription" = "他のアプリでテキストを選択し、選択ショートカットを押すと、翻訳、要約、SpotAsk への質問ができます。";
 "settings.selectionAssistantEnabled" = "選択アシスタントを有効化";
 "settings.selectionAssistantToggleShortcut" = "クイック質問モードを切り替え";

--- a/Sources/SpotAsk/Resources/pt.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/pt.lproj/Localizable.strings
@@ -371,6 +371,12 @@
 "settings.upstreamModelID" = "ID do modelo";
 "settings.useForChat" = "Usar no chat";
 "settings.selectionAssistant" = "Assistente de seleção";
+"settings.groupCore" = "Principal";
+"settings.groupAutomation" = "Automação";
+"settings.groupApp" = "App";
+"settings.searchPlaceholder" = "Pesquisar definições";
+"settings.noSearchResults" = "Nenhuma definição correspondente";
+"settings.clearSearch" = "Limpar pesquisa";
 "settings.selectionAssistantDescription" = "Selecione texto em outro app e pressione o atalho de seleção para traduzir, resumir ou perguntar ao SpotAsk.";
 "settings.selectionAssistantEnabled" = "Ativar assistente de seleção";
 "settings.selectionAssistantToggleShortcut" = "Alternar modo de pergunta rápida";

--- a/Sources/SpotAsk/Resources/ru.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/ru.lproj/Localizable.strings
@@ -371,6 +371,12 @@
 "settings.upstreamModelID" = "ID модели";
 "settings.useForChat" = "Использовать в чате";
 "settings.selectionAssistant" = "Ассистент выделения";
+"settings.groupCore" = "Основные";
+"settings.groupAutomation" = "Автоматизация";
+"settings.groupApp" = "Приложение";
+"settings.searchPlaceholder" = "Поиск настроек";
+"settings.noSearchResults" = "Подходящих настроек нет";
+"settings.clearSearch" = "Очистить поиск";
 "settings.selectionAssistantDescription" = "Выделите текст в другом приложении и нажмите сочетание выделения, чтобы перевести, кратко изложить или спросить SpotAsk.";
 "settings.selectionAssistantEnabled" = "Включить ассистента выделения";
 "settings.selectionAssistantToggleShortcut" = "Переключить режим быстрого вопроса";

--- a/Sources/SpotAsk/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/SpotAsk/Resources/zh-Hans.lproj/Localizable.strings
@@ -371,6 +371,12 @@
 "settings.upstreamModelID" = "模型 ID";
 "settings.useForChat" = "用于对话";
 "settings.selectionAssistant" = "划词助手";
+"settings.groupCore" = "核心";
+"settings.groupAutomation" = "自动化";
+"settings.groupApp" = "应用";
+"settings.searchPlaceholder" = "搜索设置";
+"settings.noSearchResults" = "没有匹配的设置";
+"settings.clearSearch" = "清除搜索";
 "settings.selectionAssistantDescription" = "在其他应用中选中文字后，按下划词快捷键即可翻译、总结或向 SpotAsk 提问。";
 "settings.selectionAssistantEnabled" = "启用划词助手";
 "settings.selectionAssistantToggleShortcut" = "切换快速提问模式";

--- a/Sources/SpotAsk/Settings/ProviderSettingsPage.swift
+++ b/Sources/SpotAsk/Settings/ProviderSettingsPage.swift
@@ -11,6 +11,8 @@ enum ProviderSettingsIcon {
 struct ProviderSettingsPage: View {
     @Bindable var settings: AppSettings
     @Bindable var state: ProviderSettingsState
+    let searchTarget: SettingsGroupTarget?
+    let onSearchTargetConsumed: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 22) {
@@ -21,7 +23,7 @@ struct ProviderSettingsPage: View {
             SettingsPageHeader(section: .provider, settings: settings)
             SettingsCallout(L10n.string("settings.providerDescription"))
 
-            ProviderSettingsList(state: state)
+            ProviderSettingsList(state: state, searchTarget: searchTarget, onSearchTargetConsumed: onSearchTargetConsumed)
         }
         .alert(L10n.string("settings.deleteProviderTitle"), isPresented: Binding(
             get: { state.pendingDeleteProviderID != nil },
@@ -795,44 +797,56 @@ private extension RequestCompatibilityProfile {
     }
 }
 
-// MARK: - Provider Settings List
-
 private struct ProviderSettingsList: View {
     @Bindable var state: ProviderSettingsState
+    let searchTarget: SettingsGroupTarget?
+    let onSearchTargetConsumed: () -> Void
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 14) {
-                if state.isCreatingProvider {
-                    NewProviderCard(state: state)
-                }
-
-                if state.providers.isEmpty, !state.isCreatingProvider {
-                    Text(L10n.string("settings.noServices"))
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 36)
-                } else {
-                    ForEach(state.providers) { provider in
-                        ProviderCard(
-                            state: state,
-                            provider: provider,
-                            models: state.modelsForProvider(provider.id)
-                        )
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    if state.isCreatingProvider {
+                        NewProviderCard(state: state)
                     }
-                }
 
-                Button {
-                    state.startNewProvider()
-                } label: {
-                    Label(L10n.string("settings.addProvider"), systemImage: "plus")
+                    if state.providers.isEmpty, !state.isCreatingProvider {
+                        Text(L10n.string("settings.noServices"))
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 36)
+                    } else {
+                        ForEach(state.providers) { provider in
+                            ProviderCard(
+                                state: state,
+                                provider: provider,
+                                models: state.modelsForProvider(provider.id)
+                            )
+                        }
+                    }
+
+                    Button {
+                        state.startNewProvider()
+                    } label: {
+                        Label(L10n.string("settings.addProvider"), systemImage: "plus")
+                    }
+                    .buttonStyle(.bordered)
+                    .padding(.top, 2)
                 }
-                .buttonStyle(.bordered)
-                .padding(.top, 2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.bottom, 12)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.bottom, 12)
+            .onAppear { scrollIfNeeded(using: proxy) }
+            .onChange(of: searchTarget) { _, _ in scrollIfNeeded(using: proxy) }
+        }
+    }
+
+    private func scrollIfNeeded(using proxy: ScrollViewProxy) {
+        guard let searchTarget, searchTarget.section == .provider else { return }
+        DispatchQueue.main.async {
+            proxy.scrollTo(searchTarget.anchor, anchor: .top)
+            onSearchTargetConsumed()
         }
     }
 }

--- a/Sources/SpotAsk/Settings/SettingsComponents.swift
+++ b/Sources/SpotAsk/Settings/SettingsComponents.swift
@@ -44,8 +44,7 @@ struct SettingsGroup<Content: View>: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text(title)
-                .font(.system(size: 17, weight: .semibold))
+            Text(title).font(.system(size: 17, weight: .semibold))
             VStack(alignment: .leading, spacing: 13) {
                 content
             }
@@ -54,6 +53,7 @@ struct SettingsGroup<Content: View>: View {
             .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .id(title)
     }
 }
 

--- a/Sources/SpotAsk/Settings/SettingsSidebar.swift
+++ b/Sources/SpotAsk/Settings/SettingsSidebar.swift
@@ -16,12 +16,11 @@ struct SettingsSidebar: View {
     @Binding var searchText: String
     let settings: AppSettings
     let visibleSections: [SettingsSection]
+    /// Results are computed by the parent so they reflect which groups can
+    /// actually render (e.g. available models only when refresh is supported).
+    let searchResults: [SettingsSearchResult]
     let onSelectResult: (SettingsSearchResult) -> Void
     @FocusState private var focusedSection: SettingsSection?
-
-    private var searchResults: [SettingsSearchResult] {
-        SettingsSearchIndex.results(for: searchText)
-    }
 
     private var sectionsByGroup: [(SettingsSectionGroup, [SettingsSection])] {
         SettingsSectionGroup.allCases.compactMap { group in

--- a/Sources/SpotAsk/Settings/SettingsSidebar.swift
+++ b/Sources/SpotAsk/Settings/SettingsSidebar.swift
@@ -7,81 +7,135 @@ enum SettingsSidebarNavigationDirection: Hashable {
 
 extension SettingsSection {
     func moving(_ direction: SettingsSidebarNavigationDirection) -> SettingsSection? {
-        guard let index = SettingsSection.allCases.firstIndex(of: self) else { return nil }
-        switch direction {
-        case .up where index > SettingsSection.allCases.startIndex:
-            return SettingsSection.allCases[SettingsSection.allCases.index(before: index)]
-        case .down where index < SettingsSection.allCases.index(before: SettingsSection.allCases.endIndex):
-            return SettingsSection.allCases[SettingsSection.allCases.index(after: index)]
-        default:
-            return nil
-        }
+        moving(direction, within: Array(SettingsSection.allCases))
     }
 }
 
 struct SettingsSidebar: View {
     @Binding var selection: SettingsSection
+    @Binding var searchText: String
     let settings: AppSettings
+    let visibleSections: [SettingsSection]
+    let onSelectResult: (SettingsSearchResult) -> Void
     @FocusState private var focusedSection: SettingsSection?
 
-    var body: some View {
-        let _ = settings.language  // observe so sidebar re-renders on language change
+    private var searchResults: [SettingsSearchResult] {
+        SettingsSearchIndex.results(for: searchText)
+    }
 
+    private var sectionsByGroup: [(SettingsSectionGroup, [SettingsSection])] {
+        SettingsSectionGroup.allCases.compactMap { group in
+            let sections = visibleSections.filter { $0.group == group }
+            return sections.isEmpty ? nil : (group, sections)
+        }
+    }
+
+    var body: some View {
+        let _ = settings.language
         VStack(alignment: .leading, spacing: 4) {
             Text(L10n.string("settings.title"))
                 .font(.system(size: 20, weight: .bold))
-                .padding(.horizontal, 18)
-                .padding(.bottom, 14)
-
-            ForEach(SettingsSection.allCases) { section in
-                Button {
-                    selection = section
-                    focusedSection = section
-                } label: {
-                    HStack(spacing: 11) {
-                        Image(systemName: section.symbol)
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(.white)
-                            .frame(width: 30, height: 30)
-                            .background(section.tint, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-                        Text(section.title)
-                            .font(.system(size: 15, weight: selection == section ? .semibold : .regular))
-                            .foregroundStyle(.primary)
-                        Spacer(minLength: 0)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 10)
+            TextField(L10n.string("settings.searchPlaceholder"), text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+                .overlay(alignment: .trailing) {
+                    if searchText.isEmpty {
+                        Image(systemName: "magnifyingglass")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .padding(.trailing, 6)
+                    } else {
+                        Button {
+                            searchText = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.trailing, 4)
+                        .accessibilityLabel(L10n.string("settings.clearSearch"))
                     }
-                    .padding(.horizontal, 12)
-                    .frame(height: 44)
-                    .contentShape(Rectangle())
-                    .background(selection == section ? Color.primary.opacity(0.1) : .clear, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
                 }
-                .buttonStyle(.plain)
-                .focusable()
-                .focused($focusedSection, equals: section)
-                .focusEffectDisabled()
-                .onKeyPress(.upArrow) {
-                    moveSelection(from: section, direction: .up)
+                .padding(.horizontal, 8)
+                .padding(.bottom, 10)
+                .accessibilityLabel(L10n.string("settings.searchPlaceholder"))
+            if searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                VStack(alignment: .leading, spacing: 14) {
+                    ForEach(sectionsByGroup, id: \.0) { group, sections in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(group.title)
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 12)
+                                .padding(.bottom, 2)
+                            ForEach(sections) { section in sectionButton(section) }
+                        }
+                    }
                 }
-                .onKeyPress(.downArrow) {
-                    moveSelection(from: section, direction: .down)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 4) {
+                        ForEach(searchResults) { result in
+                            Button { onSelectResult(result) } label: {
+                                HStack(spacing: 10) {
+                                    Image(systemName: result.target.section.symbol)
+                                        .font(.system(size: 10, weight: .semibold))
+                                        .foregroundStyle(.white)
+                                        .frame(width: 20, height: 20)
+                                        .background(result.target.section.tint, in: RoundedRectangle(cornerRadius: 5, style: .continuous))
+                                    VStack(alignment: .leading, spacing: 1) {
+                                        Text(result.title).font(.system(size: 13, weight: .medium)).foregroundStyle(.primary).lineLimit(1)
+                                        Text(result.sectionTitle).font(.caption2).foregroundStyle(.secondary).lineLimit(1)
+                                    }
+                                    Spacer(minLength: 0)
+                                }
+                                .padding(.horizontal, 12).padding(.vertical, 5).contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        if searchResults.isEmpty {
+                            Text(L10n.string("settings.noSearchResults"))
+                                .font(.caption).foregroundStyle(.secondary).padding(.horizontal, 12).padding(.vertical, 8)
+                        }
+                    }
                 }
+                .frame(maxHeight: 390)
             }
-
             Spacer()
-
             Label("SpotAsk", systemImage: "sparkle")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 18)
-                .padding(.bottom, 16)
+                .font(.caption).foregroundStyle(.secondary)
+                .padding(.horizontal, 12).padding(.bottom, 10)
         }
-        .padding(.top, 24)
-        .frame(width: 190)
+        .padding(.top, 16)
+        .frame(width: 210)
         .background(Color.primary.opacity(0.075), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
         .padding(12)
     }
 
+    private func sectionButton(_ section: SettingsSection) -> some View {
+        Button {
+            selection = section
+            focusedSection = section
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: section.symbol).font(.system(size: 12, weight: .semibold)).foregroundStyle(.white)
+                    .frame(width: 24, height: 24).background(section.tint, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                Text(section.title).font(.system(size: 13, weight: selection == section ? .semibold : .regular)).foregroundStyle(.primary)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 12).frame(height: 32).contentShape(Rectangle())
+            .background(selection == section ? Color.primary.opacity(0.1) : .clear, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .buttonStyle(.plain).focusable().focused($focusedSection, equals: section).focusEffectDisabled()
+        .onKeyPress(.upArrow) { moveSelection(from: section, direction: .up) }
+        .onKeyPress(.downArrow) { moveSelection(from: section, direction: .down) }
+    }
+
     private func moveSelection(from current: SettingsSection, direction: SettingsSidebarNavigationDirection) -> KeyPress.Result {
-        guard let next = current.moving(direction) else { return .ignored }
+        guard let next = current.moving(direction, within: visibleSections) else { return .ignored }
         selection = next
         focusedSection = next
         return .handled

--- a/Sources/SpotAsk/Settings/SettingsView.swift
+++ b/Sources/SpotAsk/Settings/SettingsView.swift
@@ -65,10 +65,27 @@ enum SettingsSection: CaseIterable, Hashable, Identifiable {
         }
     }
 
+    /// The settings window can be localized to Chinese or English while the
+    /// query arrives in the other language, so the section filter carries the
+    /// matching localized title in both languages. The content index below
+    /// applies the same treatment to every group and field label.
+    private var additionalSearchTitles: [String] {
+        switch self {
+        case .provider: ["服务设置", "Provider"]
+        case .prompts: ["提示词", "Prompts"]
+        case .externalAsk: ["外部提问", "External Ask"]
+        case .selectionAssistant: ["划词助手", "Selection Assistant"]
+        case .shortcuts: ["快捷键", "Shortcuts"]
+        case .general: ["通用", "General"]
+        case .appearance: ["外观", "Appearance"]
+        case .about: ["关于", "About"]
+        }
+    }
+
     func matches(searchText: String) -> Bool {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !query.isEmpty else { return true }
-        return ([title, group.title] + searchTerms).contains { term in
+        return ([title, group.title] + searchTerms + additionalSearchTitles).contains { term in
             term.lowercased().contains(query)
         }
     }
@@ -129,49 +146,68 @@ struct SettingsSearchResult: Identifiable, Hashable {
 enum SettingsSearchIndex {
     private struct Entry {
         let section: SettingsSection
-        let anchor: String
         let titleKey: String
         let labelKeys: [String]
     }
 
     // Keep this list beside the settings pages: labels are localization keys,
     // so search follows the language currently shown by the settings window.
+    // Only groups that always render on their page belong here — conditional
+    // groups such as the model detail form (no model selected by default) must
+    // not be exposed, or a result click would scroll to nothing.
     private static let entries: [Entry] = [
-        Entry(section: .provider, anchor: "providerInfo", titleKey: "settings.providerInfo", labelKeys: ["settings.providerName", "settings.providerFormat", "settings.serviceAddress", "settings.addressMode", "settings.responseTimeout"]),
-        Entry(section: .provider, anchor: "accessKey", titleKey: "settings.accessKey", labelKeys: ["settings.accessKey"]),
-        Entry(section: .provider, anchor: "availableModels", titleKey: "settings.availableModels", labelKeys: ["settings.modelRefreshDescription"]),
-        Entry(section: .provider, anchor: "modelInfo", titleKey: "settings.modelInfo", labelKeys: ["settings.displayName", "settings.upstreamModelID", "settings.service", "settings.streaming", "settings.requestCompatibilityProfile", "settings.thinkingMode", "settings.customRequestParameters"]),
-        Entry(section: .prompts, anchor: "savedPrompts", titleKey: "settings.savedPrompts", labelKeys: ["settings.promptCatalogDescription"]),
-        Entry(section: .prompts, anchor: "customInstruction", titleKey: "settings.customInstruction", labelKeys: ["settings.customInstruction"]),
-        Entry(section: .externalAsk, anchor: "externalAsk", titleKey: "settings.externalAsk", labelKeys: ["settings.externalAskEnabled", "settings.promptCatalogDescription"]),
-        Entry(section: .selectionAssistant, anchor: "selectionAssistant", titleKey: "settings.selectionAssistant", labelKeys: ["settings.selectionAssistantEnabled", "settings.selectionAssistantPermissionStatus", "settings.selectionAssistantMode", "settings.selectionAssistantAutoShow", "settings.selectionAssistantActionLabels", "settings.selectionAssistantActionPrompts", "settings.selectionAssistantActionExternalAsk", "settings.selectionAssistantAutoShowScope", "settings.selectionAssistantAutoShowDelay", "settings.selectionAssistantDefaultAction", "settings.selectionAssistantAutoShowApps"]),
-        Entry(section: .shortcuts, anchor: "shortcutActions", titleKey: "settings.shortcutActions", labelKeys: ["settings.selectionAssistantToggleShortcut"]),
-        Entry(section: .shortcuts, anchor: "shortcutPrompts", titleKey: "settings.shortcutPrompts", labelKeys: ["settings.promptCatalogDescription"]),
-        Entry(section: .shortcuts, anchor: "shortcutExternalAsk", titleKey: "settings.externalAsk", labelKeys: ["settings.externalAsk"]),
-        Entry(section: .general, anchor: "language", titleKey: "settings.language", labelKeys: ["settings.language"]),
-        Entry(section: .general, anchor: "behavior", titleKey: "settings.behavior", labelKeys: ["settings.globalShortcut", "settings.launchAtLogin", "settings.silentLaunch", "settings.showMenuBarIcon", "settings.restoreSession", "settings.clearInputOnClose", "settings.confirmBeforeStartingNewConversation", "settings.escapeStartsNewConversation", "settings.defaultExpandReasoning", "settings.windowOnTop", "settings.contextLimit"]),
-        Entry(section: .general, anchor: "proxy", titleKey: "settings.proxy", labelKeys: ["settings.proxyEnabled", "settings.proxyType", "settings.proxyHost", "settings.proxyPort", "settings.proxyUsername", "settings.proxyPassword"]),
-        Entry(section: .general, anchor: "diagnostics", titleKey: "settings.diagnostics", labelKeys: ["settings.diagnosticsEnabled"]),
-        Entry(section: .general, anchor: "localData", titleKey: "settings.localData", labelKeys: ["settings.localDataDescription"]),
-        Entry(section: .general, anchor: "configuration", titleKey: "settings.configuration", labelKeys: ["settings.configurationDescription"]),
-        Entry(section: .appearance, anchor: "reading", titleKey: "settings.reading", labelKeys: ["settings.appearance", "settings.chatMessageStyle", "settings.renderMath", "settings.fontSize"]),
-        Entry(section: .about, anchor: "aboutInfo", titleKey: "SpotAsk", labelKeys: ["settings.version", "settings.source", "settings.userGuide"]),
-        Entry(section: .about, anchor: "updates", titleKey: "settings.updates", labelKeys: ["settings.autoCheckForUpdates", "settings.checkForUpdates"])
+        Entry(section: .provider, titleKey: "settings.providerInfo", labelKeys: ["settings.providerName", "settings.providerFormat", "settings.serviceAddress", "settings.addressMode", "settings.responseTimeout"]),
+        Entry(section: .provider, titleKey: "settings.accessKey", labelKeys: ["settings.accessKey"]),
+        Entry(section: .provider, titleKey: "settings.availableModels", labelKeys: ["settings.modelRefreshDescription"]),
+        Entry(section: .prompts, titleKey: "settings.savedPrompts", labelKeys: ["settings.promptCatalogDescription"]),
+        Entry(section: .prompts, titleKey: "settings.customInstruction", labelKeys: ["settings.customInstruction"]),
+        Entry(section: .externalAsk, titleKey: "settings.externalAsk", labelKeys: ["settings.externalAskEnabled", "settings.promptCatalogDescription"]),
+        Entry(section: .selectionAssistant, titleKey: "settings.selectionAssistant", labelKeys: ["settings.selectionAssistantEnabled", "settings.selectionAssistantPermissionStatus", "settings.selectionAssistantMode", "settings.selectionAssistantAutoShow", "settings.selectionAssistantActionLabels", "settings.selectionAssistantActionPrompts", "settings.selectionAssistantActionExternalAsk", "settings.selectionAssistantAutoShowScope", "settings.selectionAssistantAutoShowDelay", "settings.selectionAssistantDefaultAction", "settings.selectionAssistantAutoShowApps"]),
+        Entry(section: .shortcuts, titleKey: "settings.shortcutActions", labelKeys: ["settings.selectionAssistantToggleShortcut"]),
+        Entry(section: .shortcuts, titleKey: "settings.shortcutPrompts", labelKeys: ["settings.promptCatalogDescription"]),
+        Entry(section: .shortcuts, titleKey: "settings.externalAsk", labelKeys: ["settings.externalAsk"]),
+        Entry(section: .general, titleKey: "settings.language", labelKeys: ["settings.language"]),
+        Entry(section: .general, titleKey: "settings.behavior", labelKeys: ["settings.globalShortcut", "settings.launchAtLogin", "settings.silentLaunch", "settings.showMenuBarIcon", "settings.restoreSession", "settings.clearInputOnClose", "settings.confirmBeforeStartingNewConversation", "settings.escapeStartsNewConversation", "settings.defaultExpandReasoning", "settings.windowOnTop", "settings.contextLimit"]),
+        Entry(section: .general, titleKey: "settings.proxy", labelKeys: ["settings.proxyEnabled", "settings.proxyType", "settings.proxyHost", "settings.proxyPort", "settings.proxyUsername", "settings.proxyPassword"]),
+        Entry(section: .general, titleKey: "settings.diagnostics", labelKeys: ["settings.diagnosticsEnabled"]),
+        Entry(section: .general, titleKey: "settings.localData", labelKeys: ["settings.localDataDescription"]),
+        Entry(section: .general, titleKey: "settings.configuration", labelKeys: ["settings.configurationDescription"]),
+        Entry(section: .appearance, titleKey: "settings.reading", labelKeys: ["settings.appearance", "settings.chatMessageStyle", "settings.renderMath", "settings.fontSize"]),
+        Entry(section: .about, titleKey: "SpotAsk", labelKeys: ["settings.version", "settings.source", "settings.userGuide"]),
+        Entry(section: .about, titleKey: "settings.updates", labelKeys: ["settings.autoCheckForUpdates", "settings.checkForUpdates"])
     ]
 
-    static func results(for searchText: String) -> [SettingsSearchResult] {
+    /// Settings can be displayed in Chinese or English while the query arrives
+    /// in the other language, so titles and labels are matched against the
+    /// current UI language plus both fallback locales.
+    private static let searchableLanguages: [AppLanguage] = [.simplifiedChinese, .english]
+
+    static func results(
+        for searchText: String,
+        include: ((SettingsSection, String) -> Bool)? = nil
+    ) -> [SettingsSearchResult] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !query.isEmpty else { return [] }
+        let currentLanguage = AppLanguage.current
+        let languages = ([currentLanguage] + searchableLanguages).reduce(into: [AppLanguage]()) { list, language in
+            if !list.contains(language) { list.append(language) }
+        }
         let rankedResults: [(offset: Int, result: SettingsSearchResult)] = entries.enumerated().compactMap { offset, entry in
             let title = entry.titleKey == "SpotAsk" ? "SpotAsk" : L10n.string(entry.titleKey)
+            guard include?(entry.section, title) ?? true else { return nil }
             let sectionTitle = entry.section.title
-            let descriptions = entry.labelKeys.map { L10n.string($0) }
+            let titleCandidates = Set(
+                languages.map { (entry.titleKey == "SpotAsk" ? "SpotAsk" : L10n.string(entry.titleKey, language: $0)).lowercased() }
+            )
+            let descriptionCandidates = Set(
+                languages.flatMap { language in entry.labelKeys.map { L10n.string($0, language: language).lowercased() } }
+            )
             let matchPriority: Int
-            if title.lowercased().contains(query) {
+            if titleCandidates.contains(where: { $0.contains(query) }) {
                 matchPriority = 0
             } else if sectionTitle.lowercased().contains(query) {
                 matchPriority = 1
-            } else if descriptions.contains(where: { $0.lowercased().contains(query) }) {
+            } else if descriptionCandidates.contains(where: { $0.contains(query) }) {
                 matchPriority = 2
             } else {
                 return nil
@@ -209,6 +245,10 @@ struct SettingsView: View {
     @State private var searchText = ""
     @State private var pendingGroupTarget: SettingsGroupTarget?
 
+    private var searchResults: [SettingsSearchResult] {
+        SettingsSearchIndex.results(for: searchText, include: isSearchResultReachable)
+    }
+
     private var visibleSections: [SettingsSection] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else { return Array(SettingsSection.allCases) }
@@ -217,7 +257,7 @@ struct SettingsView: View {
         // label can match even when it is not listed in section.searchTerms;
         // keep that result's destination visible so cross-section navigation
         // cannot fall back to the first unrelated page.
-        let indexedSections = SettingsSearchIndex.results(for: query).map(\.target.section)
+        let indexedSections = searchResults.map(\.target.section)
         let sections = SettingsSection.allCases.filter {
             $0.matches(searchText: query) || indexedSections.contains($0)
         }
@@ -266,6 +306,7 @@ struct SettingsView: View {
                 searchText: $searchText,
                 settings: settings,
                 visibleSections: visibleSections,
+                searchResults: searchResults,
                 onSelectResult: { result in
                     selectedSection = result.target.section
                     pendingGroupTarget = result.target
@@ -339,6 +380,16 @@ struct SettingsView: View {
             StatusToastOverlay()
                 .padding(.top, 36)
         }
+    }
+
+    /// The available-models group only renders when the selected provider
+    /// supports model refresh; everything else in the index always renders on
+    /// its page, so every exposed result can actually scroll somewhere.
+    private func isSearchResultReachable(section: SettingsSection, anchor: String) -> Bool {
+        if section == .provider, anchor == L10n.string("settings.availableModels") {
+            return providerState.selectedProviderSupportsModelRefresh
+        }
+        return true
     }
 }
 

--- a/Sources/SpotAsk/Settings/SettingsView.swift
+++ b/Sources/SpotAsk/Settings/SettingsView.swift
@@ -1,6 +1,22 @@
 import AppKit
 import SwiftUI
 
+enum SettingsSectionGroup: CaseIterable, Hashable, Identifiable {
+    case core
+    case automation
+    case app
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .core: L10n.string("settings.groupCore")
+        case .automation: L10n.string("settings.groupAutomation")
+        case .app: L10n.string("settings.groupApp")
+        }
+    }
+}
+
 enum SettingsSection: CaseIterable, Hashable, Identifiable {
     case provider
     case prompts
@@ -23,6 +39,49 @@ enum SettingsSection: CaseIterable, Hashable, Identifiable {
         case .general: L10n.string("settings.general")
         case .appearance: L10n.string("settings.appearance")
         case .about: L10n.string("settings.about")
+        }
+    }
+
+    var group: SettingsSectionGroup {
+        switch self {
+        case .provider, .prompts, .externalAsk: .core
+        case .selectionAssistant, .shortcuts: .automation
+        case .general, .appearance, .about: .app
+        }
+    }
+
+    /// Search terms describe the controls on each page, not just its title.
+    /// The content index below supplies the group and field labels as well.
+    var searchTerms: [String] {
+        switch self {
+        case .provider: ["service", "provider", "model", "models", "access key", "endpoint", "connection", "服务", "模型", "密钥", "地址"]
+        case .prompts: ["prompt", "prompts", "instruction", "preset", "提示词", "指令"]
+        case .externalAsk: ["external ask", "quick action", "web", "app", "terminal", "外部提问", "网页", "应用", "终端"]
+        case .selectionAssistant: ["selection", "selected text", "accessibility", "application", "划词", "选中文字", "辅助功能", "应用"]
+        case .shortcuts: ["shortcut", "keyboard", "command", "快捷键", "键盘"]
+        case .general: ["behavior", "proxy", "diagnostics", "language", "launch", "window", "local data", "configuration", "行为", "代理", "诊断", "语言", "启动", "窗口", "数据", "配置"]
+        case .appearance: ["appearance", "reading", "color", "font", "math", "style", "外观", "阅读", "颜色", "字体"]
+        case .about: ["about", "version", "update", "documentation", "关于", "版本", "更新", "文档"]
+        }
+    }
+
+    func matches(searchText: String) -> Bool {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return true }
+        return ([title, group.title] + searchTerms).contains { term in
+            term.lowercased().contains(query)
+        }
+    }
+
+    func moving(_ direction: SettingsSidebarNavigationDirection, within sections: [SettingsSection]) -> SettingsSection? {
+        guard let index = sections.firstIndex(of: self) else { return nil }
+        switch direction {
+        case .up where index > sections.startIndex:
+            return sections[sections.index(before: index)]
+        case .down where index < sections.index(before: sections.endIndex):
+            return sections[sections.index(after: index)]
+        default:
+            return nil
         }
     }
 
@@ -53,6 +112,90 @@ enum SettingsSection: CaseIterable, Hashable, Identifiable {
     }
 }
 
+struct SettingsGroupTarget: Hashable {
+    let section: SettingsSection
+    let anchor: String
+}
+
+struct SettingsSearchResult: Identifiable, Hashable {
+    let target: SettingsGroupTarget
+    let title: String
+    let sectionTitle: String
+    let matchPriority: Int
+
+    var id: SettingsGroupTarget { target }
+}
+
+enum SettingsSearchIndex {
+    private struct Entry {
+        let section: SettingsSection
+        let anchor: String
+        let titleKey: String
+        let labelKeys: [String]
+    }
+
+    // Keep this list beside the settings pages: labels are localization keys,
+    // so search follows the language currently shown by the settings window.
+    private static let entries: [Entry] = [
+        Entry(section: .provider, anchor: "providerInfo", titleKey: "settings.providerInfo", labelKeys: ["settings.providerName", "settings.providerFormat", "settings.serviceAddress", "settings.addressMode", "settings.responseTimeout"]),
+        Entry(section: .provider, anchor: "accessKey", titleKey: "settings.accessKey", labelKeys: ["settings.accessKey"]),
+        Entry(section: .provider, anchor: "availableModels", titleKey: "settings.availableModels", labelKeys: ["settings.modelRefreshDescription"]),
+        Entry(section: .provider, anchor: "modelInfo", titleKey: "settings.modelInfo", labelKeys: ["settings.displayName", "settings.upstreamModelID", "settings.service", "settings.streaming", "settings.requestCompatibilityProfile", "settings.thinkingMode", "settings.customRequestParameters"]),
+        Entry(section: .prompts, anchor: "savedPrompts", titleKey: "settings.savedPrompts", labelKeys: ["settings.promptCatalogDescription"]),
+        Entry(section: .prompts, anchor: "customInstruction", titleKey: "settings.customInstruction", labelKeys: ["settings.customInstruction"]),
+        Entry(section: .externalAsk, anchor: "externalAsk", titleKey: "settings.externalAsk", labelKeys: ["settings.externalAskEnabled", "settings.promptCatalogDescription"]),
+        Entry(section: .selectionAssistant, anchor: "selectionAssistant", titleKey: "settings.selectionAssistant", labelKeys: ["settings.selectionAssistantEnabled", "settings.selectionAssistantPermissionStatus", "settings.selectionAssistantMode", "settings.selectionAssistantAutoShow", "settings.selectionAssistantActionLabels", "settings.selectionAssistantActionPrompts", "settings.selectionAssistantActionExternalAsk", "settings.selectionAssistantAutoShowScope", "settings.selectionAssistantAutoShowDelay", "settings.selectionAssistantDefaultAction", "settings.selectionAssistantAutoShowApps"]),
+        Entry(section: .shortcuts, anchor: "shortcutActions", titleKey: "settings.shortcutActions", labelKeys: ["settings.selectionAssistantToggleShortcut"]),
+        Entry(section: .shortcuts, anchor: "shortcutPrompts", titleKey: "settings.shortcutPrompts", labelKeys: ["settings.promptCatalogDescription"]),
+        Entry(section: .shortcuts, anchor: "shortcutExternalAsk", titleKey: "settings.externalAsk", labelKeys: ["settings.externalAsk"]),
+        Entry(section: .general, anchor: "language", titleKey: "settings.language", labelKeys: ["settings.language"]),
+        Entry(section: .general, anchor: "behavior", titleKey: "settings.behavior", labelKeys: ["settings.globalShortcut", "settings.launchAtLogin", "settings.silentLaunch", "settings.showMenuBarIcon", "settings.restoreSession", "settings.clearInputOnClose", "settings.confirmBeforeStartingNewConversation", "settings.escapeStartsNewConversation", "settings.defaultExpandReasoning", "settings.windowOnTop", "settings.contextLimit"]),
+        Entry(section: .general, anchor: "proxy", titleKey: "settings.proxy", labelKeys: ["settings.proxyEnabled", "settings.proxyType", "settings.proxyHost", "settings.proxyPort", "settings.proxyUsername", "settings.proxyPassword"]),
+        Entry(section: .general, anchor: "diagnostics", titleKey: "settings.diagnostics", labelKeys: ["settings.diagnosticsEnabled"]),
+        Entry(section: .general, anchor: "localData", titleKey: "settings.localData", labelKeys: ["settings.localDataDescription"]),
+        Entry(section: .general, anchor: "configuration", titleKey: "settings.configuration", labelKeys: ["settings.configurationDescription"]),
+        Entry(section: .appearance, anchor: "reading", titleKey: "settings.reading", labelKeys: ["settings.appearance", "settings.chatMessageStyle", "settings.renderMath", "settings.fontSize"]),
+        Entry(section: .about, anchor: "aboutInfo", titleKey: "SpotAsk", labelKeys: ["settings.version", "settings.source", "settings.userGuide"]),
+        Entry(section: .about, anchor: "updates", titleKey: "settings.updates", labelKeys: ["settings.autoCheckForUpdates", "settings.checkForUpdates"])
+    ]
+
+    static func results(for searchText: String) -> [SettingsSearchResult] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return [] }
+        let rankedResults: [(offset: Int, result: SettingsSearchResult)] = entries.enumerated().compactMap { offset, entry in
+            let title = entry.titleKey == "SpotAsk" ? "SpotAsk" : L10n.string(entry.titleKey)
+            let sectionTitle = entry.section.title
+            let descriptions = entry.labelKeys.map { L10n.string($0) }
+            let matchPriority: Int
+            if title.lowercased().contains(query) {
+                matchPriority = 0
+            } else if sectionTitle.lowercased().contains(query) {
+                matchPriority = 1
+            } else if descriptions.contains(where: { $0.lowercased().contains(query) }) {
+                matchPriority = 2
+            } else {
+                return nil
+            }
+            let result = SettingsSearchResult(
+                target: SettingsGroupTarget(section: entry.section, anchor: title),
+                title: title,
+                sectionTitle: sectionTitle,
+                matchPriority: matchPriority
+            )
+            return (offset, result)
+        }
+        return rankedResults
+            .sorted { lhs, rhs in
+                if lhs.result.matchPriority != rhs.result.matchPriority {
+                    return lhs.result.matchPriority < rhs.result.matchPriority
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.result)
+    }
+}
+
+
 struct SettingsView: View {
     let settings: AppSettings
     let accessibilityPermissionCoordinator: AccessibilityPermissionCoordinator
@@ -63,6 +206,30 @@ struct SettingsView: View {
     @State private var providerState: ProviderSettingsState
     @State private var generalState: GeneralSettingsState
     @State private var updateState = AppUpdateState()
+    @State private var searchText = ""
+    @State private var pendingGroupTarget: SettingsGroupTarget?
+
+    private var visibleSections: [SettingsSection] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return Array(SettingsSection.allCases) }
+
+        // The sidebar section filter and the content index must agree. A field
+        // label can match even when it is not listed in section.searchTerms;
+        // keep that result's destination visible so cross-section navigation
+        // cannot fall back to the first unrelated page.
+        let indexedSections = SettingsSearchIndex.results(for: query).map(\.target.section)
+        let sections = SettingsSection.allCases.filter {
+            $0.matches(searchText: query) || indexedSections.contains($0)
+        }
+        return sections
+    }
+
+    private var resolvedSelection: SettingsSection {
+        guard visibleSections.contains(selectedSection) else {
+            return visibleSections.first ?? selectedSection
+        }
+        return selectedSection
+    }
 
     init(
         settings: AppSettings,
@@ -94,22 +261,45 @@ struct SettingsView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            SettingsSidebar(selection: $selectedSection, settings: settings)
+            SettingsSidebar(
+                selection: $selectedSection,
+                searchText: $searchText,
+                settings: settings,
+                visibleSections: visibleSections,
+                onSelectResult: { result in
+                    selectedSection = result.target.section
+                    pendingGroupTarget = result.target
+                }
+            )
             Divider()
             Group {
-                switch selectedSection {
+                switch resolvedSelection {
                 case .provider:
-                    ProviderSettingsPage(settings: settings, state: providerState)
+                    ProviderSettingsPage(
+                        settings: settings,
+                        state: providerState,
+                        searchTarget: pendingGroupTarget,
+                        onSearchTargetConsumed: { pendingGroupTarget = nil }
+                    )
                 case .prompts:
-                    ScrollView {
+                    SettingsPageScrollView(
+                        section: .prompts,
+                        pendingTarget: $pendingGroupTarget
+                    ) {
                         PromptPresetsSettingsPage(settings: settings)
                     }
                 case .externalAsk:
-                    ScrollView {
+                    SettingsPageScrollView(
+                        section: .externalAsk,
+                        pendingTarget: $pendingGroupTarget
+                    ) {
                         ExternalAskSettingsPage(settings: settings)
                     }
                 case .selectionAssistant:
-                    ScrollView {
+                    SettingsPageScrollView(
+                        section: .selectionAssistant,
+                        pendingTarget: $pendingGroupTarget
+                    ) {
                         SelectionAssistantSettingsPage(
                             settings: settings,
                             permissionCoordinator: accessibilityPermissionCoordinator,
@@ -118,11 +308,17 @@ struct SettingsView: View {
                         )
                     }
                 case .shortcuts:
-                    ScrollView {
+                    SettingsPageScrollView(
+                        section: .shortcuts,
+                        pendingTarget: $pendingGroupTarget
+                    ) {
                         ShortcutSettingsPage(settings: settings)
                     }
                 case .general:
-                    ScrollView {
+                    SettingsPageScrollView(
+                        section: .general,
+                        pendingTarget: $pendingGroupTarget
+                    ) {
                         GeneralSettingsPage(settings: settings, generalState: generalState)
                     }
                 case .appearance:
@@ -142,6 +338,35 @@ struct SettingsView: View {
         .overlay(alignment: .topTrailing) {
             StatusToastOverlay()
                 .padding(.top, 36)
+        }
+    }
+}
+
+private struct SettingsPageScrollView<Content: View>: View {
+    let section: SettingsSection
+    @Binding var pendingTarget: SettingsGroupTarget?
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                content
+            }
+            .onAppear {
+                scrollIfNeeded(using: proxy)
+            }
+            .onChange(of: pendingTarget) { _, _ in
+                scrollIfNeeded(using: proxy)
+            }
+        }
+        .id(section)
+    }
+
+    private func scrollIfNeeded(using proxy: ScrollViewProxy) {
+        guard let target = pendingTarget, target.section == section else { return }
+        DispatchQueue.main.async {
+            proxy.scrollTo(target.anchor, anchor: .top)
+            pendingTarget = nil
         }
     }
 }

--- a/Tests/SpotAskTests/SettingsLayoutTests.swift
+++ b/Tests/SpotAskTests/SettingsLayoutTests.swift
@@ -48,6 +48,43 @@ struct SettingsLayoutTests {
         }
     }
 
+    @Test func settingsSearchMatchesChineseAndEnglishRegardlessOfInterfaceLanguage() {
+        // The proxy group is indexed as "settings.proxy"; the query must hit
+        // whether the UI shows 代理 (zh-Hans) or Proxy (en).
+        for query in ["proxy", "代理"] {
+            let results = SettingsSearchIndex.results(for: query)
+            #expect(results.contains { $0.target.section == .general }, "expected a general-section result for \(query)")
+        }
+
+        // Model details only render while a model is being edited, so the
+        // group must never appear as a search result.
+        for query in ["model details", "模型详情"] {
+            let results = SettingsSearchIndex.results(for: query)
+            #expect(!results.contains { $0.title == L10n.string("settings.modelInfo") }, "modelInfo must not be indexed for \(query)")
+        }
+    }
+    @Test func settingsSearchHidesAvailableModelsWhenProviderCannotRefresh() {
+        let availableModelsTitle = L10n.string("settings.availableModels")
+
+        // The default test provider does not support model refresh, so the
+        // group is not on screen and must not be offered as a jump target,
+        // even when the query hits its description text.
+        let hidden = SettingsSearchIndex.results(for: "models available") { section, anchor in
+            !(section == .provider && anchor == availableModelsTitle)
+        }
+        #expect(!hidden.contains { $0.target.section == .provider && $0.title == availableModelsTitle })
+
+        // Other provider groups stay reachable under the same filter.
+        let providerInfoResults = SettingsSearchIndex.results(for: "service details") { section, anchor in
+            !(section == .provider && anchor == availableModelsTitle)
+        }
+        #expect(providerInfoResults.contains { $0.target.section == .provider && $0.title == L10n.string("settings.providerInfo") })
+
+        // Without the reachability filter the group is found as usual.
+        let unfiltered = SettingsSearchIndex.results(for: "models available")
+        #expect(unfiltered.contains { $0.target.section == .provider && $0.title == availableModelsTitle })
+    }
+
     @Test func providerPageScrollingRevealsBottomControls() throws {
         let fixture = makeWindow(section: .provider)
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }

--- a/Tests/SpotAskTests/SettingsLayoutTests.swift
+++ b/Tests/SpotAskTests/SettingsLayoutTests.swift
@@ -18,6 +18,35 @@ struct SettingsLayoutTests {
         #expect(SettingsSection.about.moving(.down) == nil)
         #expect(SettingsSection.provider.moving(.up) == nil)
     }
+    @Test func settingsSearchMatchesSectionsAndMovesWithinFilteredResults() {
+        #expect(SettingsSection.general.matches(searchText: "proxy"))
+        #expect(!SettingsSection.about.matches(searchText: "proxy"))
+        #expect(SettingsSection.provider.moving(.down, within: [.provider, .general]) == .general)
+        #expect(SettingsSection.general.moving(.up, within: [.provider, .general]) == .provider)
+        #expect(SettingsSection.provider.moving(.up, within: [.provider, .general]) == nil)
+    }
+
+    @Test func settingsSearchIndexReturnsContentGroupTargets() {
+        let proxy = SettingsSearchIndex.results(for: "proxy")
+        #expect(proxy.contains { $0.target == SettingsGroupTarget(section: .general, anchor: "Proxy") })
+
+        let language = SettingsSearchIndex.results(for: "language")
+        #expect(language.contains { $0.target.section == .general })
+    }
+    @Test func settingsSearchRanksTitlesBeforeDescriptions() {
+        let prompts = SettingsSearchIndex.results(for: "prompt")
+        #expect(prompts.map(\.matchPriority) == prompts.map(\.matchPriority).sorted())
+
+        let promptShortcutIndex = prompts.firstIndex {
+            $0.target.section == .shortcuts && $0.title == L10n.string("settings.shortcutPrompts")
+        }
+        let descriptionIndex = prompts.firstIndex { $0.target.section == .externalAsk }
+        #expect(promptShortcutIndex != nil)
+        #expect(descriptionIndex != nil)
+        if let promptShortcutIndex, let descriptionIndex {
+            #expect(promptShortcutIndex < descriptionIndex)
+        }
+    }
 
     @Test func providerPageScrollingRevealsBottomControls() throws {
         let fixture = makeWindow(section: .provider)


### PR DESCRIPTION
Closes DEV-68

## What
Restyles the settings sidebar to match the LookAway-style reference the user endorsed, fixing the "左侧还是不一致" visual gap:

- Section rows: 32pt height with 24pt icons (was 44pt / 30pt) — matches the compact look of the reference sidebar.
- Group headers: plain semibold 12pt secondary text (was uppercase 11pt tracked style).
- Search-result rows: compact 20pt icons with tighter vertical padding.
- Unified 12pt horizontal padding across title, search field, section rows and footer.
- Carries the full DEV-68 feature set (Core / Automation / App grouping, bilingual settings search with content index, keyboard navigation) and merges latest `main` (global shortcut clearing, idle reasoning refresh fix).

## Verification
- `swift test --filter SettingsLayoutTests` — 13 tests pass.
- Rebuilt and installed `SpotAsk Debug.app`; opened settings window via Computer Use and visually confirmed the new sidebar renders grouped sections + search field in the compact style.