### PR TITLE
ui(settings): gradient icon tiles for sidebar and page headers

### DIFF
--- a/Sources/SpotAsk/Settings/SettingsComponents.swift
+++ b/Sources/SpotAsk/Settings/SettingsComponents.swift
@@ -14,7 +14,10 @@ struct SettingsPageHeader: View {
                 .font(.system(size: 18, weight: .semibold))
                 .foregroundStyle(.white)
                 .frame(width: 40, height: 40)
-                .background(section.tint, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .background(
+                    LinearGradient(colors: section.tintGradient, startPoint: .top, endPoint: .bottom),
+                    in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+                )
             Text(section.title)
                 .font(.system(size: 27, weight: .bold))
         }

--- a/Sources/SpotAsk/Settings/SettingsSidebar.swift
+++ b/Sources/SpotAsk/Settings/SettingsSidebar.swift
@@ -84,7 +84,10 @@ struct SettingsSidebar: View {
                                         .font(.system(size: 10, weight: .semibold))
                                         .foregroundStyle(.white)
                                         .frame(width: 20, height: 20)
-                                        .background(result.target.section.tint, in: RoundedRectangle(cornerRadius: 5, style: .continuous))
+                                        .background(
+                                            LinearGradient(colors: result.target.section.tintGradient, startPoint: .top, endPoint: .bottom),
+                                            in: RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                        )
                                     VStack(alignment: .leading, spacing: 1) {
                                         Text(result.title).font(.system(size: 13, weight: .medium)).foregroundStyle(.primary).lineLimit(1)
                                         Text(result.sectionTitle).font(.caption2).foregroundStyle(.secondary).lineLimit(1)
@@ -121,7 +124,11 @@ struct SettingsSidebar: View {
         } label: {
             HStack(spacing: 8) {
                 Image(systemName: section.symbol).font(.system(size: 12, weight: .semibold)).foregroundStyle(.white)
-                    .frame(width: 24, height: 24).background(section.tint, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .frame(width: 24, height: 24)
+                    .background(
+                        LinearGradient(colors: section.tintGradient, startPoint: .top, endPoint: .bottom),
+                        in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    )
                 Text(section.title).font(.system(size: 13, weight: selection == section ? .semibold : .regular)).foregroundStyle(.primary)
                 Spacer(minLength: 0)
             }

--- a/Sources/SpotAsk/Settings/SettingsView.swift
+++ b/Sources/SpotAsk/Settings/SettingsView.swift
@@ -129,19 +129,19 @@ enum SettingsSection: CaseIterable, Hashable, Identifiable {
     }
 
     /// LookAway-style icon tiles fade from a lighter tone at the top to a
-    /// deeper tone at the bottom, which keeps the tiles vivid without reading
-    /// as flat color blocks. Sections within one group stay in the same hue
-    /// family so the sidebar reads as grouped gradients.
+    /// deeper tone at the bottom. The stops are sampled from the LookAway
+    /// reference the user endorsed: warm hues (pink → red → orange → amber)
+    /// flowing down the sidebar instead of cool system colors.
     var tintGradient: [Color] {
         switch self {
-        case .provider: [Color(red: 0.45, green: 0.82, blue: 0.96), Color(red: 0.10, green: 0.55, blue: 0.78)]
-        case .prompts: [Color(red: 0.45, green: 0.90, blue: 0.72), Color(red: 0.08, green: 0.62, blue: 0.45)]
-        case .externalAsk: [Color(red: 0.48, green: 0.72, blue: 1.00), Color(red: 0.12, green: 0.42, blue: 0.92)]
-        case .selectionAssistant: [Color(red: 0.40, green: 0.88, blue: 0.82), Color(red: 0.05, green: 0.60, blue: 0.60)]
-        case .shortcuts: [Color(red: 1.00, green: 0.72, blue: 0.40), Color(red: 0.90, green: 0.45, blue: 0.10)]
-        case .general: [Color(red: 0.72, green: 0.72, blue: 0.76), Color(red: 0.42, green: 0.42, blue: 0.48)]
-        case .appearance: [Color(red: 0.68, green: 0.62, blue: 1.00), Color(red: 0.42, green: 0.32, blue: 0.88)]
-        case .about: [Color(red: 0.82, green: 0.58, blue: 1.00), Color(red: 0.58, green: 0.25, blue: 0.85)]
+        case .provider: [Color(red: 0.98, green: 0.42, blue: 0.85), Color(red: 0.88, green: 0.20, blue: 0.63)]  // LookAway pink #F96BD8→#E134A1
+        case .prompts: [Color(red: 0.99, green: 0.36, blue: 0.67), Color(red: 0.91, green: 0.24, blue: 0.58)]   // #FC5CAB→#E83E94
+        case .externalAsk: [Color(red: 0.99, green: 0.38, blue: 0.58), Color(red: 0.90, green: 0.27, blue: 0.50)] // #FC6194→#E64580
+        case .selectionAssistant: [Color(red: 0.98, green: 0.43, blue: 0.43), Color(red: 0.89, green: 0.33, blue: 0.35)] // #FA6E6E→#E35459
+        case .shortcuts: [Color(red: 0.96, green: 0.50, blue: 0.24), Color(red: 0.85, green: 0.42, blue: 0.19)] // #F5803D→#D96B30
+        case .general: [Color(red: 1.00, green: 0.62, blue: 0.09), Color(red: 0.85, green: 0.52, blue: 0.01)]   // #FE9E17→#D98502
+        case .appearance: [Color(red: 0.98, green: 0.67, blue: 0.00), Color(red: 0.88, green: 0.58, blue: 0.00)] // #FAAB00→#E19400
+        case .about: [Color(red: 0.87, green: 0.71, blue: 0.19), Color(red: 0.72, green: 0.58, blue: 0.13)]     // #DEB531→#B89421
         }
     }
 }

--- a/Sources/SpotAsk/Settings/SettingsView.swift
+++ b/Sources/SpotAsk/Settings/SettingsView.swift
@@ -127,6 +127,23 @@ enum SettingsSection: CaseIterable, Hashable, Identifiable {
         case .about: .purple
         }
     }
+
+    /// LookAway-style icon tiles fade from a lighter tone at the top to a
+    /// deeper tone at the bottom, which keeps the tiles vivid without reading
+    /// as flat color blocks. Sections within one group stay in the same hue
+    /// family so the sidebar reads as grouped gradients.
+    var tintGradient: [Color] {
+        switch self {
+        case .provider: [Color(red: 0.45, green: 0.82, blue: 0.96), Color(red: 0.10, green: 0.55, blue: 0.78)]
+        case .prompts: [Color(red: 0.45, green: 0.90, blue: 0.72), Color(red: 0.08, green: 0.62, blue: 0.45)]
+        case .externalAsk: [Color(red: 0.48, green: 0.72, blue: 1.00), Color(red: 0.12, green: 0.42, blue: 0.92)]
+        case .selectionAssistant: [Color(red: 0.40, green: 0.88, blue: 0.82), Color(red: 0.05, green: 0.60, blue: 0.60)]
+        case .shortcuts: [Color(red: 1.00, green: 0.72, blue: 0.40), Color(red: 0.90, green: 0.45, blue: 0.10)]
+        case .general: [Color(red: 0.72, green: 0.72, blue: 0.76), Color(red: 0.42, green: 0.42, blue: 0.48)]
+        case .appearance: [Color(red: 0.68, green: 0.62, blue: 1.00), Color(red: 0.42, green: 0.32, blue: 0.88)]
+        case .about: [Color(red: 0.82, green: 0.58, blue: 1.00), Color(red: 0.58, green: 0.25, blue: 0.85)]
+        }
+    }
 }
 
 struct SettingsGroupTarget: Hashable {


### PR DESCRIPTION
Closes DEV-68

## What
- Adds `SettingsSection.tintGradient`: a warm pink → red → orange → amber sequence sampled from the accepted LookAway reference.
- Applies the vertical two-stop gradient to sidebar rows, search-result icons, and page-header icons.
- Keeps sidebar surfaces and selection backgrounds neutral so the color hierarchy remains concentrated in icon tiles.

## Verification
- `swift test` — 193/193 passed.
- Rebuilt and reinstalled `SpotAsk Debug.app`; verified the settings window visually.
- Human visual acceptance recorded in DEV-68: “这版感觉可以的”.
